### PR TITLE
Fix escape sequence rendering in character literals

### DIFF
--- a/docs/site/dt31/operands.html
+++ b/docs/site/dt31/operands.html
@@ -237,432 +237,441 @@
 </span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
 </span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
 </span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">is_char</span><span class="p">:</span>
-</span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a>            <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;&#39;</span><span class="si">{</span><span class="nb">chr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span><span class="si">}</span><span class="s2">&#39;&quot;</span>
-</span><span id="L-71"><a href="#L-71"><span class="linenos"> 71</span></a>        <span class="k">return</span> <span class="nb">str</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
-</span><span id="L-72"><a href="#L-72"><span class="linenos"> 72</span></a>
-</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="L-74"><a href="#L-74"><span class="linenos"> 74</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="L-75"><a href="#L-75"><span class="linenos"> 75</span></a>            <span class="k">return</span> <span class="n">other</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
-</span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a>        <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Literal</span><span class="p">):</span>
-</span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a>            <span class="k">return</span> <span class="n">other</span><span class="o">.</span><span class="n">value</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
-</span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a>        <span class="k">return</span> <span class="kc">False</span>
-</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>
-</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>
-</span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaLiteral</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
-</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating Literal operands.&quot;&quot;&quot;</span>
-</span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a>
-</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Literal</span><span class="p">:</span>
-</span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a Literal operand using bracket syntax.</span>
-</span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>
-</span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a><span class="sd">        Args:</span>
-</span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a><span class="sd">            arg: The integer value for the literal.</span>
+</span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a>            <span class="n">char_str</span> <span class="o">=</span> <span class="nb">chr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
+</span><span id="L-71"><a href="#L-71"><span class="linenos"> 71</span></a>            <span class="c1"># Special case for single quote: repr(&quot;&#39;&quot;) -&gt; &quot;&#39;&quot; (uses double quotes)</span>
+</span><span id="L-72"><a href="#L-72"><span class="linenos"> 72</span></a>            <span class="c1"># We need to escape it for our single-quote syntax</span>
+</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a>            <span class="k">if</span> <span class="n">char_str</span> <span class="o">==</span> <span class="s2">&quot;&#39;&quot;</span><span class="p">:</span>
+</span><span id="L-74"><a href="#L-74"><span class="linenos"> 74</span></a>                <span class="k">return</span> <span class="sa">r</span><span class="s2">&quot;&#39;\&#39;&#39;&quot;</span>
+</span><span id="L-75"><a href="#L-75"><span class="linenos"> 75</span></a>            <span class="c1"># For all other characters, repr() handles escaping correctly</span>
+</span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a>            <span class="c1"># repr(&quot;A&quot;) -&gt; &quot;&#39;A&#39;&quot;, repr(&quot;\n&quot;) -&gt; &quot;&#39;\n&#39;&quot;, repr(&quot;\\&quot;) -&gt; &quot;&#39;\\\\&#39;&quot;, etc.</span>
+</span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a>            <span class="n">escaped</span> <span class="o">=</span> <span class="nb">repr</span><span class="p">(</span><span class="n">char_str</span><span class="p">)</span>
+</span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a>            <span class="c1"># Strip the outer quotes that repr() adds and wrap in single quotes</span>
+</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>            <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;&#39;</span><span class="si">{</span><span class="n">escaped</span><span class="p">[</span><span class="mi">1</span><span class="p">:</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span><span class="si">}</span><span class="s2">&#39;&quot;</span>
+</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>        <span class="k">return</span> <span class="nb">str</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
+</span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a>
+</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a>            <span class="k">return</span> <span class="n">other</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
+</span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a>        <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Literal</span><span class="p">):</span>
+</span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>            <span class="k">return</span> <span class="n">other</span><span class="o">.</span><span class="n">value</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
+</span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a>
 </span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a>
-</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a><span class="sd">        Returns:</span>
-</span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a><span class="sd">            A Literal operand with the specified value.</span>
-</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a>
+</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaLiteral</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
+</span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating Literal operands.&quot;&quot;&quot;</span>
+</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>
+</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Literal</span><span class="p">:</span>
+</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a Literal operand using bracket syntax.</span>
 </span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a>
-</span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a><span class="k">class</span><span class="w"> </span><span class="nc">L</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaLiteral</span><span class="p">):</span>
-</span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating Literal operands using bracket syntax.</span>
+</span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a><span class="sd">        Args:</span>
+</span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a><span class="sd">            arg: The integer value for the literal.</span>
 </span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>
-</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a><span class="sd">    Examples:</span>
-</span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a><span class="sd">        L[42]  # Creates Literal(42)</span>
-</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a><span class="sd">        L[0]   # Creates Literal(0)</span>
-</span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a><span class="sd">        Returns:</span>
+</span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a><span class="sd">            A Literal operand with the specified value.</span>
+</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
 </span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a>
-</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>    <span class="k">pass</span>
-</span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>
-</span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>
-</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaCharLiteral</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
-</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating character Literal operands.&quot;&quot;&quot;</span>
-</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a>
-</span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Literal</span><span class="p">:</span>
-</span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a Literal operand from a character using bracket syntax.</span>
+</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>
+</span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a><span class="k">class</span><span class="w"> </span><span class="nc">L</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaLiteral</span><span class="p">):</span>
+</span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating Literal operands using bracket syntax.</span>
+</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>
+</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a><span class="sd">    Examples:</span>
+</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a><span class="sd">        L[42]  # Creates Literal(42)</span>
+</span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a><span class="sd">        L[0]   # Creates Literal(0)</span>
+</span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>
-</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a><span class="sd">        Args:</span>
-</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a><span class="sd">            arg: A single character string.</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>    <span class="k">pass</span>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>
 </span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>
-</span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a><span class="sd">        Returns:</span>
-</span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a><span class="sd">            A Literal operand with the character&#39;s ordinal value, marked as a character.</span>
+</span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaCharLiteral</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
+</span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating character Literal operands.&quot;&quot;&quot;</span>
 </span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a>
-</span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a><span class="sd">        Raises:</span>
-</span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a><span class="sd">            ValueError: If arg is not a single character string.</span>
-</span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">str</span><span class="p">)</span> <span class="ow">or</span> <span class="nb">len</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span> <span class="o">!=</span> <span class="mi">1</span><span class="p">:</span>
-</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a>            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;LC requires a single character, got: </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
-</span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="nb">ord</span><span class="p">(</span><span class="n">arg</span><span class="p">),</span> <span class="n">is_char</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
-</span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a>
-</span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a>
-</span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a><span class="k">class</span><span class="w"> </span><span class="nc">LC</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaCharLiteral</span><span class="p">):</span>
-</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating character Literal operands using bracket syntax.</span>
-</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a>
-</span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a><span class="sd">    Examples:</span>
-</span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a><span class="sd">        LC[&#39;A&#39;]  # Creates Literal(65)</span>
-</span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a><span class="sd">        LC[&#39;z&#39;]  # Creates Literal(122)</span>
-</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Literal</span><span class="p">:</span>
+</span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a Literal operand from a character using bracket syntax.</span>
+</span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a>
+</span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a><span class="sd">        Args:</span>
+</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a><span class="sd">            arg: A single character string.</span>
+</span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a>
+</span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a><span class="sd">        Returns:</span>
+</span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a><span class="sd">            A Literal operand with the character&#39;s ordinal value, marked as a character.</span>
+</span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a>
+</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a><span class="sd">        Raises:</span>
+</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a><span class="sd">            ValueError: If arg is not a single character string.</span>
+</span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a>        <span class="k">if</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">str</span><span class="p">)</span> <span class="ow">or</span> <span class="nb">len</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span> <span class="o">!=</span> <span class="mi">1</span><span class="p">:</span>
+</span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a>            <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;LC requires a single character, got: </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2">&quot;</span><span class="p">)</span>
+</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="nb">ord</span><span class="p">(</span><span class="n">arg</span><span class="p">),</span> <span class="n">is_char</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </span><span id="L-134"><a href="#L-134"><span class="linenos">134</span></a>
-</span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>    <span class="k">pass</span>
-</span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a>
-</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a>
-</span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a><span class="k">class</span><span class="w"> </span><span class="nc">MemoryReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
-</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a memory address reference.</span>
-</span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a>
-</span><span id="L-141"><a href="#L-141"><span class="linenos">141</span></a><span class="sd">    Memory references resolve to the value stored at a memory address.</span>
-</span><span id="L-142"><a href="#L-142"><span class="linenos">142</span></a><span class="sd">    The address itself can be a constant or another operand (indirect addressing).</span>
-</span><span id="L-143"><a href="#L-143"><span class="linenos">143</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>
-</span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
-</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a>
-</span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a><span class="sd">        Args:</span>
-</span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
-</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
-</span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
+</span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>
+</span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a><span class="k">class</span><span class="w"> </span><span class="nc">LC</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaCharLiteral</span><span class="p">):</span>
+</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating character Literal operands using bracket syntax.</span>
+</span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a>
+</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a><span class="sd">    Examples:</span>
+</span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a><span class="sd">        LC[&#39;A&#39;]  # Creates Literal(65)</span>
+</span><span id="L-141"><a href="#L-141"><span class="linenos">141</span></a><span class="sd">        LC[&#39;z&#39;]  # Creates Literal(122)</span>
+</span><span id="L-142"><a href="#L-142"><span class="linenos">142</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-143"><a href="#L-143"><span class="linenos">143</span></a>
+</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>    <span class="k">pass</span>
+</span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>
+</span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a>
+</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a><span class="k">class</span><span class="w"> </span><span class="nc">MemoryReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
+</span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a memory address reference.</span>
+</span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a>
+</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a><span class="sd">    Memory references resolve to the value stored at a memory address.</span>
+</span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a><span class="sd">    The address itself can be a constant or another operand (indirect addressing).</span>
+</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>
-</span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
+</span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
 </span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a>
 </span><span id="L-157"><a href="#L-157"><span class="linenos">157</span></a><span class="sd">        Args:</span>
-</span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
-</span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a>
-</span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a><span class="sd">        Returns:</span>
-</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a><span class="sd">            The value stored at the resolved memory address.</span>
-</span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
-</span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a>
-</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
-</span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a>
-</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a><span class="sd">        Args:</span>
-</span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
-</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a>
-</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a><span class="sd">        Returns:</span>
-</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a><span class="sd">            The integer memory address.</span>
-</span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
-</span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a>
-</span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;M[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">!r}</span><span class="s2">]&quot;</span>
+</span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
+</span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
+</span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
+</span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a>
+</span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
+</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>
+</span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a><span class="sd">        Args:</span>
+</span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
+</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>
+</span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a><span class="sd">        Returns:</span>
+</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a><span class="sd">            The value stored at the resolved memory address.</span>
+</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
+</span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a>
+</span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
+</span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a>
+</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a><span class="sd">        Args:</span>
+</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
 </span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a>
-</span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
-</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">}</span><span class="s2">]&quot;</span>
-</span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a>
+</span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a><span class="sd">        Returns:</span>
+</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a><span class="sd">            The integer memory address.</span>
+</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
 </span><span id="L-184"><a href="#L-184"><span class="linenos">184</span></a>
-</span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaMemory</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
-</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating MemoryReference operands.&quot;&quot;&quot;</span>
-</span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a>
-</span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">MemoryReference</span><span class="p">:</span>
-</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a MemoryReference operand using bracket syntax.</span>
-</span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a>
-</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a><span class="sd">        Args:</span>
-</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a><span class="sd">            arg: The memory address, either as an integer or another operand.</span>
+</span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;M[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">!r}</span><span class="s2">]&quot;</span>
+</span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>
+</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
+</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">}</span><span class="s2">]&quot;</span>
+</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>
 </span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a>
-</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a><span class="sd">        Returns:</span>
-</span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a><span class="sd">            A MemoryReference operand for the specified address.</span>
-</span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>        <span class="k">return</span> <span class="n">MemoryReference</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>
+</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaMemory</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
+</span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling bracket syntax for creating MemoryReference operands.&quot;&quot;&quot;</span>
+</span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>
+</span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getitem__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">MemoryReference</span><span class="p">:</span>
+</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a MemoryReference operand using bracket syntax.</span>
 </span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a>
-</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a><span class="k">class</span><span class="w"> </span><span class="nc">M</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaMemory</span><span class="p">):</span>
-</span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating MemoryReference operands using bracket syntax.</span>
+</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a><span class="sd">        Args:</span>
+</span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a><span class="sd">            arg: The memory address, either as an integer or another operand.</span>
 </span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a>
-</span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a><span class="sd">    Examples:</span>
-</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a><span class="sd">        M[100]      # Direct memory access at address 100</span>
-</span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a><span class="sd">        M[R.a]      # Indirect memory access using register &#39;a&#39; as address</span>
-</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a><span class="sd">        M[M[50]]    # Double indirect addressing</span>
-</span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a><span class="sd">        Returns:</span>
+</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a><span class="sd">            A MemoryReference operand for the specified address.</span>
+</span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a>        <span class="k">return</span> <span class="n">MemoryReference</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
+</span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a>
 </span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>
-</span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a>    <span class="k">pass</span>
-</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a>
+</span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a><span class="k">class</span><span class="w"> </span><span class="nc">M</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaMemory</span><span class="p">):</span>
+</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating MemoryReference operands using bracket syntax.</span>
 </span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a>
-</span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="k">def</span><span class="w"> </span><span class="nf">validate_register_name</span><span class="p">(</span><span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Validate that a register name is a valid Python identifier.</span>
-</span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a>
-</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a><span class="sd">    Register names must be valid Python identifiers and cannot start with</span>
-</span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a><span class="sd">    double underscores to avoid conflicts with dunder methods.</span>
+</span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a><span class="sd">    Examples:</span>
+</span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a><span class="sd">        M[100]      # Direct memory access at address 100</span>
+</span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a><span class="sd">        M[R.a]      # Indirect memory access using register &#39;a&#39; as address</span>
+</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a><span class="sd">        M[M[50]]    # Double indirect addressing</span>
+</span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a>
-</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a><span class="sd">    Args:</span>
-</span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a><span class="sd">        name: The register name to validate.</span>
+</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a>    <span class="k">pass</span>
+</span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a>
 </span><span id="L-220"><a href="#L-220"><span class="linenos">220</span></a>
-</span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a><span class="sd">    Raises:</span>
-</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a><span class="sd">        ValueError: If the register name is not a valid Python identifier</span>
-</span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a><span class="sd">            or starts with double underscores.</span>
-</span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>
-</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a><span class="sd">    Examples:</span>
-</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;a&quot;)  # Valid</span>
-</span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my_reg&quot;)  # Valid</span>
-</span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;reg123&quot;)  # Valid</span>
-</span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;_private&quot;)  # Valid</span>
-</span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;123&quot;)  # Raises ValueError</span>
-</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my-reg&quot;)  # Raises ValueError</span>
-</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;__dunder__&quot;)  # Raises ValueError</span>
-</span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>    <span class="k">if</span> <span class="ow">not</span> <span class="n">name</span><span class="o">.</span><span class="n">isidentifier</span><span class="p">():</span>
-</span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
-</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
-</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names must be valid Python identifiers &quot;</span>
-</span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>            <span class="sa">f</span><span class="s2">&quot;(letters, digits, underscores; cannot start with a digit).&quot;</span>
-</span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>        <span class="p">)</span>
-</span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a>    <span class="k">if</span> <span class="n">name</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
-</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
-</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
-</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names cannot start with double underscores (reserved for dunder methods).&quot;</span>
-</span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>        <span class="p">)</span>
-</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>
-</span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>
-</span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RegisterReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
-</span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a CPU register reference.</span>
-</span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>
-</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a><span class="sd">    Register references resolve to the value stored in the named register.</span>
-</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>
-</span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
-</span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
-</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a><span class="sd">    for dunder methods).</span>
-</span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a>
-</span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
-</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>
-</span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a><span class="sd">        Args:</span>
-</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
-</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
-</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a>
-</span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a><span class="sd">        Raises:</span>
-</span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
-</span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a><span class="sd">                starts with double underscores.</span>
-</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
-</span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
-</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a>
-</span><span id="L-271"><a href="#L-271"><span class="linenos">271</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-272"><a href="#L-272"><span class="linenos">272</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
-</span><span id="L-273"><a href="#L-273"><span class="linenos">273</span></a>
-</span><span id="L-274"><a href="#L-274"><span class="linenos">274</span></a><span class="sd">        Args:</span>
-</span><span id="L-275"><a href="#L-275"><span class="linenos">275</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
-</span><span id="L-276"><a href="#L-276"><span class="linenos">276</span></a>
-</span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a><span class="sd">        Returns:</span>
-</span><span id="L-278"><a href="#L-278"><span class="linenos">278</span></a><span class="sd">            The value currently stored in the referenced register.</span>
-</span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-280"><a href="#L-280"><span class="linenos">280</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
-</span><span id="L-281"><a href="#L-281"><span class="linenos">281</span></a>
-</span><span id="L-282"><a href="#L-282"><span class="linenos">282</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-283"><a href="#L-283"><span class="linenos">283</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="L-284"><a href="#L-284"><span class="linenos">284</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a><span class="k">def</span><span class="w"> </span><span class="nf">validate_register_name</span><span class="p">(</span><span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Validate that a register name is a valid Python identifier.</span>
+</span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>
+</span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a><span class="sd">    Register names must be valid Python identifiers and cannot start with</span>
+</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a><span class="sd">    double underscores to avoid conflicts with dunder methods.</span>
+</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a>
+</span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a><span class="sd">    Args:</span>
+</span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a><span class="sd">        name: The register name to validate.</span>
+</span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a>
+</span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a><span class="sd">    Raises:</span>
+</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a><span class="sd">        ValueError: If the register name is not a valid Python identifier</span>
+</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a><span class="sd">            or starts with double underscores.</span>
+</span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a>
+</span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a><span class="sd">    Examples:</span>
+</span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;a&quot;)  # Valid</span>
+</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my_reg&quot;)  # Valid</span>
+</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;reg123&quot;)  # Valid</span>
+</span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;_private&quot;)  # Valid</span>
+</span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;123&quot;)  # Raises ValueError</span>
+</span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my-reg&quot;)  # Raises ValueError</span>
+</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;__dunder__&quot;)  # Raises ValueError</span>
+</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>    <span class="k">if</span> <span class="ow">not</span> <span class="n">name</span><span class="o">.</span><span class="n">isidentifier</span><span class="p">():</span>
+</span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
+</span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names must be valid Python identifiers &quot;</span>
+</span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a>            <span class="sa">f</span><span class="s2">&quot;(letters, digits, underscores; cannot start with a digit).&quot;</span>
+</span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>        <span class="p">)</span>
+</span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>    <span class="k">if</span> <span class="n">name</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
+</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
+</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
+</span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names cannot start with double underscores (reserved for dunder methods).&quot;</span>
+</span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a>        <span class="p">)</span>
+</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a>
+</span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a>
+</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RegisterReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
+</span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a CPU register reference.</span>
+</span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a>
+</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a><span class="sd">    Register references resolve to the value stored in the named register.</span>
+</span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a>
+</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
+</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
+</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a><span class="sd">    for dunder methods).</span>
+</span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a>
+</span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
+</span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>
+</span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a><span class="sd">        Args:</span>
+</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
+</span><span id="L-271"><a href="#L-271"><span class="linenos">271</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
+</span><span id="L-272"><a href="#L-272"><span class="linenos">272</span></a>
+</span><span id="L-273"><a href="#L-273"><span class="linenos">273</span></a><span class="sd">        Raises:</span>
+</span><span id="L-274"><a href="#L-274"><span class="linenos">274</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
+</span><span id="L-275"><a href="#L-275"><span class="linenos">275</span></a><span class="sd">                starts with double underscores.</span>
+</span><span id="L-276"><a href="#L-276"><span class="linenos">276</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-277"><a href="#L-277"><span class="linenos">277</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
+</span><span id="L-278"><a href="#L-278"><span class="linenos">278</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
+</span><span id="L-279"><a href="#L-279"><span class="linenos">279</span></a>
+</span><span id="L-280"><a href="#L-280"><span class="linenos">280</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="L-281"><a href="#L-281"><span class="linenos">281</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
+</span><span id="L-282"><a href="#L-282"><span class="linenos">282</span></a>
+</span><span id="L-283"><a href="#L-283"><span class="linenos">283</span></a><span class="sd">        Args:</span>
+</span><span id="L-284"><a href="#L-284"><span class="linenos">284</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
 </span><span id="L-285"><a href="#L-285"><span class="linenos">285</span></a>
-</span><span id="L-286"><a href="#L-286"><span class="linenos">286</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-287"><a href="#L-287"><span class="linenos">287</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
-</span><span id="L-288"><a href="#L-288"><span class="linenos">288</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
-</span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a>
+</span><span id="L-286"><a href="#L-286"><span class="linenos">286</span></a><span class="sd">        Returns:</span>
+</span><span id="L-287"><a href="#L-287"><span class="linenos">287</span></a><span class="sd">            The value currently stored in the referenced register.</span>
+</span><span id="L-288"><a href="#L-288"><span class="linenos">288</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-289"><a href="#L-289"><span class="linenos">289</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
 </span><span id="L-290"><a href="#L-290"><span class="linenos">290</span></a>
-</span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaRegister</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
-</span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling attribute syntax for RegisterReference operands.&quot;&quot;&quot;</span>
-</span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>
-</span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getattribute__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a RegisterReference using attribute syntax.</span>
-</span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a>
-</span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a><span class="sd">        Args:</span>
-</span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a><span class="sd">            arg: The name of the register.</span>
+</span><span id="L-291"><a href="#L-291"><span class="linenos">291</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-292"><a href="#L-292"><span class="linenos">292</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="L-293"><a href="#L-293"><span class="linenos">293</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="L-294"><a href="#L-294"><span class="linenos">294</span></a>
+</span><span id="L-295"><a href="#L-295"><span class="linenos">295</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-296"><a href="#L-296"><span class="linenos">296</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
+</span><span id="L-297"><a href="#L-297"><span class="linenos">297</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="L-298"><a href="#L-298"><span class="linenos">298</span></a>
 </span><span id="L-299"><a href="#L-299"><span class="linenos">299</span></a>
-</span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a><span class="sd">        Returns:</span>
-</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a><span class="sd">            A RegisterReference operand, unless accessing special attributes.</span>
+</span><span id="L-300"><a href="#L-300"><span class="linenos">300</span></a><span class="k">class</span><span class="w"> </span><span class="nc">_MetaRegister</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
+</span><span id="L-301"><a href="#L-301"><span class="linenos">301</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Metaclass enabling attribute syntax for RegisterReference operands.&quot;&quot;&quot;</span>
 </span><span id="L-302"><a href="#L-302"><span class="linenos">302</span></a>
-</span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a><span class="sd">        Raises:</span>
-</span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier.</span>
-</span><span id="L-305"><a href="#L-305"><span class="linenos">305</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-306"><a href="#L-306"><span class="linenos">306</span></a>        <span class="c1"># Don&#39;t intercept special attributes (dunder methods)</span>
-</span><span id="L-307"><a href="#L-307"><span class="linenos">307</span></a>        <span class="k">if</span> <span class="n">arg</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
-</span><span id="L-308"><a href="#L-308"><span class="linenos">308</span></a>            <span class="k">return</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__getattribute__</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="L-309"><a href="#L-309"><span class="linenos">309</span></a>        <span class="k">return</span> <span class="n">RegisterReference</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a>
+</span><span id="L-303"><a href="#L-303"><span class="linenos">303</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__getattribute__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">arg</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="L-304"><a href="#L-304"><span class="linenos">304</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a RegisterReference using attribute syntax.</span>
+</span><span id="L-305"><a href="#L-305"><span class="linenos">305</span></a>
+</span><span id="L-306"><a href="#L-306"><span class="linenos">306</span></a><span class="sd">        Args:</span>
+</span><span id="L-307"><a href="#L-307"><span class="linenos">307</span></a><span class="sd">            arg: The name of the register.</span>
+</span><span id="L-308"><a href="#L-308"><span class="linenos">308</span></a>
+</span><span id="L-309"><a href="#L-309"><span class="linenos">309</span></a><span class="sd">        Returns:</span>
+</span><span id="L-310"><a href="#L-310"><span class="linenos">310</span></a><span class="sd">            A RegisterReference operand, unless accessing special attributes.</span>
 </span><span id="L-311"><a href="#L-311"><span class="linenos">311</span></a>
-</span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a><span class="k">class</span><span class="w"> </span><span class="nc">R</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaRegister</span><span class="p">):</span>
-</span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating RegisterReference operands.</span>
-</span><span id="L-314"><a href="#L-314"><span class="linenos">314</span></a>
-</span><span id="L-315"><a href="#L-315"><span class="linenos">315</span></a><span class="sd">    Uses attribute syntax for ergonomic register references.</span>
-</span><span id="L-316"><a href="#L-316"><span class="linenos">316</span></a>
-</span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
-</span><span id="L-318"><a href="#L-318"><span class="linenos">318</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
-</span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a><span class="sd">    for dunder methods).</span>
+</span><span id="L-312"><a href="#L-312"><span class="linenos">312</span></a><span class="sd">        Raises:</span>
+</span><span id="L-313"><a href="#L-313"><span class="linenos">313</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier.</span>
+</span><span id="L-314"><a href="#L-314"><span class="linenos">314</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-315"><a href="#L-315"><span class="linenos">315</span></a>        <span class="c1"># Don&#39;t intercept special attributes (dunder methods)</span>
+</span><span id="L-316"><a href="#L-316"><span class="linenos">316</span></a>        <span class="k">if</span> <span class="n">arg</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
+</span><span id="L-317"><a href="#L-317"><span class="linenos">317</span></a>            <span class="k">return</span> <span class="nb">super</span><span class="p">()</span><span class="o">.</span><span class="fm">__getattribute__</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
+</span><span id="L-318"><a href="#L-318"><span class="linenos">318</span></a>        <span class="k">return</span> <span class="n">RegisterReference</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
+</span><span id="L-319"><a href="#L-319"><span class="linenos">319</span></a>
 </span><span id="L-320"><a href="#L-320"><span class="linenos">320</span></a>
-</span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a><span class="sd">    Examples:</span>
-</span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a><span class="sd">        R.a         # Creates RegisterReference(&quot;a&quot;)</span>
-</span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a><span class="sd">        R.foo       # Creates RegisterReference(&quot;foo&quot;)</span>
-</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a><span class="sd">        R.my_reg    # Creates RegisterReference(&quot;my_reg&quot;)</span>
-</span><span id="L-325"><a href="#L-325"><span class="linenos">325</span></a><span class="sd">        R._temp     # Creates RegisterReference(&quot;_temp&quot;) - valid</span>
-</span><span id="L-326"><a href="#L-326"><span class="linenos">326</span></a><span class="sd">        R.__dunder  # Raises ValueError - double underscore prefix not allowed</span>
-</span><span id="L-327"><a href="#L-327"><span class="linenos">327</span></a><span class="sd">        R.123       # SyntaxError - identifiers cannot start with digits</span>
-</span><span id="L-328"><a href="#L-328"><span class="linenos">328</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-321"><a href="#L-321"><span class="linenos">321</span></a><span class="k">class</span><span class="w"> </span><span class="nc">R</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaRegister</span><span class="p">):</span>
+</span><span id="L-322"><a href="#L-322"><span class="linenos">322</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating RegisterReference operands.</span>
+</span><span id="L-323"><a href="#L-323"><span class="linenos">323</span></a>
+</span><span id="L-324"><a href="#L-324"><span class="linenos">324</span></a><span class="sd">    Uses attribute syntax for ergonomic register references.</span>
+</span><span id="L-325"><a href="#L-325"><span class="linenos">325</span></a>
+</span><span id="L-326"><a href="#L-326"><span class="linenos">326</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
+</span><span id="L-327"><a href="#L-327"><span class="linenos">327</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
+</span><span id="L-328"><a href="#L-328"><span class="linenos">328</span></a><span class="sd">    for dunder methods).</span>
 </span><span id="L-329"><a href="#L-329"><span class="linenos">329</span></a>
-</span><span id="L-330"><a href="#L-330"><span class="linenos">330</span></a>    <span class="k">pass</span>
-</span><span id="L-331"><a href="#L-331"><span class="linenos">331</span></a>
-</span><span id="L-332"><a href="#L-332"><span class="linenos">332</span></a>
-</span><span id="L-333"><a href="#L-333"><span class="linenos">333</span></a><span class="n">Reference</span> <span class="o">=</span> <span class="n">RegisterReference</span> <span class="o">|</span> <span class="n">MemoryReference</span>
-</span><span id="L-334"><a href="#L-334"><span class="linenos">334</span></a>
-</span><span id="L-335"><a href="#L-335"><span class="linenos">335</span></a>
-</span><span id="L-336"><a href="#L-336"><span class="linenos">336</span></a><span class="k">def</span><span class="w"> </span><span class="nf">as_op</span><span class="p">(</span><span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="L-337"><a href="#L-337"><span class="linenos">337</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Coerce a value into an Operand.</span>
+</span><span id="L-330"><a href="#L-330"><span class="linenos">330</span></a><span class="sd">    Examples:</span>
+</span><span id="L-331"><a href="#L-331"><span class="linenos">331</span></a><span class="sd">        R.a         # Creates RegisterReference(&quot;a&quot;)</span>
+</span><span id="L-332"><a href="#L-332"><span class="linenos">332</span></a><span class="sd">        R.foo       # Creates RegisterReference(&quot;foo&quot;)</span>
+</span><span id="L-333"><a href="#L-333"><span class="linenos">333</span></a><span class="sd">        R.my_reg    # Creates RegisterReference(&quot;my_reg&quot;)</span>
+</span><span id="L-334"><a href="#L-334"><span class="linenos">334</span></a><span class="sd">        R._temp     # Creates RegisterReference(&quot;_temp&quot;) - valid</span>
+</span><span id="L-335"><a href="#L-335"><span class="linenos">335</span></a><span class="sd">        R.__dunder  # Raises ValueError - double underscore prefix not allowed</span>
+</span><span id="L-336"><a href="#L-336"><span class="linenos">336</span></a><span class="sd">        R.123       # SyntaxError - identifiers cannot start with digits</span>
+</span><span id="L-337"><a href="#L-337"><span class="linenos">337</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-338"><a href="#L-338"><span class="linenos">338</span></a>
-</span><span id="L-339"><a href="#L-339"><span class="linenos">339</span></a><span class="sd">    Converts integers to Literal operands, while passing through existing operands.</span>
+</span><span id="L-339"><a href="#L-339"><span class="linenos">339</span></a>    <span class="k">pass</span>
 </span><span id="L-340"><a href="#L-340"><span class="linenos">340</span></a>
-</span><span id="L-341"><a href="#L-341"><span class="linenos">341</span></a><span class="sd">    Args:</span>
-</span><span id="L-342"><a href="#L-342"><span class="linenos">342</span></a><span class="sd">        arg: Either an integer to be converted or an existing Operand.</span>
+</span><span id="L-341"><a href="#L-341"><span class="linenos">341</span></a>
+</span><span id="L-342"><a href="#L-342"><span class="linenos">342</span></a><span class="n">Reference</span> <span class="o">=</span> <span class="n">RegisterReference</span> <span class="o">|</span> <span class="n">MemoryReference</span>
 </span><span id="L-343"><a href="#L-343"><span class="linenos">343</span></a>
-</span><span id="L-344"><a href="#L-344"><span class="linenos">344</span></a><span class="sd">    Returns:</span>
-</span><span id="L-345"><a href="#L-345"><span class="linenos">345</span></a><span class="sd">        An Operand instance (either the input operand or a new Literal).</span>
-</span><span id="L-346"><a href="#L-346"><span class="linenos">346</span></a>
-</span><span id="L-347"><a href="#L-347"><span class="linenos">347</span></a><span class="sd">    Raises:</span>
-</span><span id="L-348"><a href="#L-348"><span class="linenos">348</span></a><span class="sd">        ValueError: If the argument cannot be coerced into an operand.</span>
-</span><span id="L-349"><a href="#L-349"><span class="linenos">349</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-350"><a href="#L-350"><span class="linenos">350</span></a>    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="L-351"><a href="#L-351"><span class="linenos">351</span></a>        <span class="k">return</span> <span class="n">arg</span>
-</span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a>    <span class="k">else</span><span class="p">:</span>
-</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;can&#39;t coerce value </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2"> into operand&quot;</span><span class="p">)</span>
-</span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a>
-</span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a>
-</span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="k">class</span><span class="w"> </span><span class="nc">Label</span><span class="p">:</span>
-</span><span id="L-359"><a href="#L-359"><span class="linenos">359</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A named label that marks a position in the program for jumps and calls.</span>
-</span><span id="L-360"><a href="#L-360"><span class="linenos">360</span></a>
-</span><span id="L-361"><a href="#L-361"><span class="linenos">361</span></a><span class="sd">    Labels are assembly-time constructs used to mark instruction positions in a program.</span>
-</span><span id="L-362"><a href="#L-362"><span class="linenos">362</span></a><span class="sd">    They are removed during the assembly process and replaced with numeric instruction</span>
-</span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a><span class="sd">    indices. Labels can only be used as destinations for jump and call instructions.</span>
-</span><span id="L-364"><a href="#L-364"><span class="linenos">364</span></a>
-</span><span id="L-365"><a href="#L-365"><span class="linenos">365</span></a><span class="sd">    Usage</span>
-</span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a><span class="sd">    -----</span>
-</span><span id="L-367"><a href="#L-367"><span class="linenos">367</span></a><span class="sd">    Labels are used in two contexts:</span>
-</span><span id="L-368"><a href="#L-368"><span class="linenos">368</span></a>
-</span><span id="L-369"><a href="#L-369"><span class="linenos">369</span></a><span class="sd">    1. **Definition**: Place a Label directly in the program list to mark a position:</span>
-</span><span id="L-370"><a href="#L-370"><span class="linenos">370</span></a><span class="sd">       ```python</span>
-</span><span id="L-371"><a href="#L-371"><span class="linenos">371</span></a><span class="sd">       program = [</span>
-</span><span id="L-372"><a href="#L-372"><span class="linenos">372</span></a><span class="sd">           I.CP(R.a, L[0]),</span>
-</span><span id="L-373"><a href="#L-373"><span class="linenos">373</span></a><span class="sd">           Label(&quot;loop&quot;),      # Marks this position</span>
-</span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a><span class="sd">           I.ADD(R.a, L[1]),</span>
-</span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a><span class="sd">       ]</span>
-</span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="sd">       ```</span>
+</span><span id="L-344"><a href="#L-344"><span class="linenos">344</span></a>
+</span><span id="L-345"><a href="#L-345"><span class="linenos">345</span></a><span class="k">def</span><span class="w"> </span><span class="nf">as_op</span><span class="p">(</span><span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="L-346"><a href="#L-346"><span class="linenos">346</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Coerce a value into an Operand.</span>
+</span><span id="L-347"><a href="#L-347"><span class="linenos">347</span></a>
+</span><span id="L-348"><a href="#L-348"><span class="linenos">348</span></a><span class="sd">    Converts integers to Literal operands, while passing through existing operands.</span>
+</span><span id="L-349"><a href="#L-349"><span class="linenos">349</span></a>
+</span><span id="L-350"><a href="#L-350"><span class="linenos">350</span></a><span class="sd">    Args:</span>
+</span><span id="L-351"><a href="#L-351"><span class="linenos">351</span></a><span class="sd">        arg: Either an integer to be converted or an existing Operand.</span>
+</span><span id="L-352"><a href="#L-352"><span class="linenos">352</span></a>
+</span><span id="L-353"><a href="#L-353"><span class="linenos">353</span></a><span class="sd">    Returns:</span>
+</span><span id="L-354"><a href="#L-354"><span class="linenos">354</span></a><span class="sd">        An Operand instance (either the input operand or a new Literal).</span>
+</span><span id="L-355"><a href="#L-355"><span class="linenos">355</span></a>
+</span><span id="L-356"><a href="#L-356"><span class="linenos">356</span></a><span class="sd">    Raises:</span>
+</span><span id="L-357"><a href="#L-357"><span class="linenos">357</span></a><span class="sd">        ValueError: If the argument cannot be coerced into an operand.</span>
+</span><span id="L-358"><a href="#L-358"><span class="linenos">358</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-359"><a href="#L-359"><span class="linenos">359</span></a>    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="L-360"><a href="#L-360"><span class="linenos">360</span></a>        <span class="k">return</span> <span class="n">arg</span>
+</span><span id="L-361"><a href="#L-361"><span class="linenos">361</span></a>    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="L-362"><a href="#L-362"><span class="linenos">362</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
+</span><span id="L-363"><a href="#L-363"><span class="linenos">363</span></a>    <span class="k">else</span><span class="p">:</span>
+</span><span id="L-364"><a href="#L-364"><span class="linenos">364</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;can&#39;t coerce value </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2"> into operand&quot;</span><span class="p">)</span>
+</span><span id="L-365"><a href="#L-365"><span class="linenos">365</span></a>
+</span><span id="L-366"><a href="#L-366"><span class="linenos">366</span></a>
+</span><span id="L-367"><a href="#L-367"><span class="linenos">367</span></a><span class="k">class</span><span class="w"> </span><span class="nc">Label</span><span class="p">:</span>
+</span><span id="L-368"><a href="#L-368"><span class="linenos">368</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A named label that marks a position in the program for jumps and calls.</span>
+</span><span id="L-369"><a href="#L-369"><span class="linenos">369</span></a>
+</span><span id="L-370"><a href="#L-370"><span class="linenos">370</span></a><span class="sd">    Labels are assembly-time constructs used to mark instruction positions in a program.</span>
+</span><span id="L-371"><a href="#L-371"><span class="linenos">371</span></a><span class="sd">    They are removed during the assembly process and replaced with numeric instruction</span>
+</span><span id="L-372"><a href="#L-372"><span class="linenos">372</span></a><span class="sd">    indices. Labels can only be used as destinations for jump and call instructions.</span>
+</span><span id="L-373"><a href="#L-373"><span class="linenos">373</span></a>
+</span><span id="L-374"><a href="#L-374"><span class="linenos">374</span></a><span class="sd">    Usage</span>
+</span><span id="L-375"><a href="#L-375"><span class="linenos">375</span></a><span class="sd">    -----</span>
+</span><span id="L-376"><a href="#L-376"><span class="linenos">376</span></a><span class="sd">    Labels are used in two contexts:</span>
 </span><span id="L-377"><a href="#L-377"><span class="linenos">377</span></a>
-</span><span id="L-378"><a href="#L-378"><span class="linenos">378</span></a><span class="sd">    2. **Reference**: Use a Label as the destination operand in jump/call instructions:</span>
+</span><span id="L-378"><a href="#L-378"><span class="linenos">378</span></a><span class="sd">    1. **Definition**: Place a Label directly in the program list to mark a position:</span>
 </span><span id="L-379"><a href="#L-379"><span class="linenos">379</span></a><span class="sd">       ```python</span>
-</span><span id="L-380"><a href="#L-380"><span class="linenos">380</span></a><span class="sd">       I.JMP(Label(&quot;loop&quot;))     # Jump to the position marked by &quot;loop&quot;</span>
-</span><span id="L-381"><a href="#L-381"><span class="linenos">381</span></a><span class="sd">       I.CALL(Label(&quot;func&quot;))    # Call the function at &quot;func&quot;</span>
-</span><span id="L-382"><a href="#L-382"><span class="linenos">382</span></a><span class="sd">       I.RJGT(Label(&quot;start&quot;), R.a, L[10])  # Conditional relative jump</span>
-</span><span id="L-383"><a href="#L-383"><span class="linenos">383</span></a><span class="sd">       ```</span>
-</span><span id="L-384"><a href="#L-384"><span class="linenos">384</span></a>
-</span><span id="L-385"><a href="#L-385"><span class="linenos">385</span></a><span class="sd">    Valid Instructions for Labels</span>
-</span><span id="L-386"><a href="#L-386"><span class="linenos">386</span></a><span class="sd">    ------------------------------</span>
-</span><span id="L-387"><a href="#L-387"><span class="linenos">387</span></a><span class="sd">    Labels can ONLY be used as the `dest` argument in these instructions:</span>
-</span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a><span class="sd">    - Absolute jumps: JMP, JEQ, JNE, JGT, JGE, JIF</span>
-</span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="sd">    - Relative jumps: RJMP, RJEQ, RJNE, RJGT, RJGE, RJIF</span>
-</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a><span class="sd">    - Function calls: CALL, RCALL</span>
-</span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a>
-</span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a><span class="sd">    Invalid Usage</span>
-</span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a><span class="sd">    -------------</span>
-</span><span id="L-394"><a href="#L-394"><span class="linenos">394</span></a><span class="sd">    Labels cannot be used in arithmetic, logic, or other operations:</span>
-</span><span id="L-395"><a href="#L-395"><span class="linenos">395</span></a><span class="sd">    ```python</span>
-</span><span id="L-396"><a href="#L-396"><span class="linenos">396</span></a><span class="sd">    I.ADD(R.a, Label(&quot;x&quot;))      # INVALID - will cause runtime error</span>
-</span><span id="L-397"><a href="#L-397"><span class="linenos">397</span></a><span class="sd">    I.CP(Label(&quot;foo&quot;), R.b)     # INVALID - will cause runtime error</span>
-</span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a><span class="sd">    M[Label(&quot;addr&quot;)]            # INVALID - will cause runtime error</span>
-</span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a><span class="sd">    ```</span>
+</span><span id="L-380"><a href="#L-380"><span class="linenos">380</span></a><span class="sd">       program = [</span>
+</span><span id="L-381"><a href="#L-381"><span class="linenos">381</span></a><span class="sd">           I.CP(R.a, L[0]),</span>
+</span><span id="L-382"><a href="#L-382"><span class="linenos">382</span></a><span class="sd">           Label(&quot;loop&quot;),      # Marks this position</span>
+</span><span id="L-383"><a href="#L-383"><span class="linenos">383</span></a><span class="sd">           I.ADD(R.a, L[1]),</span>
+</span><span id="L-384"><a href="#L-384"><span class="linenos">384</span></a><span class="sd">       ]</span>
+</span><span id="L-385"><a href="#L-385"><span class="linenos">385</span></a><span class="sd">       ```</span>
+</span><span id="L-386"><a href="#L-386"><span class="linenos">386</span></a>
+</span><span id="L-387"><a href="#L-387"><span class="linenos">387</span></a><span class="sd">    2. **Reference**: Use a Label as the destination operand in jump/call instructions:</span>
+</span><span id="L-388"><a href="#L-388"><span class="linenos">388</span></a><span class="sd">       ```python</span>
+</span><span id="L-389"><a href="#L-389"><span class="linenos">389</span></a><span class="sd">       I.JMP(Label(&quot;loop&quot;))     # Jump to the position marked by &quot;loop&quot;</span>
+</span><span id="L-390"><a href="#L-390"><span class="linenos">390</span></a><span class="sd">       I.CALL(Label(&quot;func&quot;))    # Call the function at &quot;func&quot;</span>
+</span><span id="L-391"><a href="#L-391"><span class="linenos">391</span></a><span class="sd">       I.RJGT(Label(&quot;start&quot;), R.a, L[10])  # Conditional relative jump</span>
+</span><span id="L-392"><a href="#L-392"><span class="linenos">392</span></a><span class="sd">       ```</span>
+</span><span id="L-393"><a href="#L-393"><span class="linenos">393</span></a>
+</span><span id="L-394"><a href="#L-394"><span class="linenos">394</span></a><span class="sd">    Valid Instructions for Labels</span>
+</span><span id="L-395"><a href="#L-395"><span class="linenos">395</span></a><span class="sd">    ------------------------------</span>
+</span><span id="L-396"><a href="#L-396"><span class="linenos">396</span></a><span class="sd">    Labels can ONLY be used as the `dest` argument in these instructions:</span>
+</span><span id="L-397"><a href="#L-397"><span class="linenos">397</span></a><span class="sd">    - Absolute jumps: JMP, JEQ, JNE, JGT, JGE, JIF</span>
+</span><span id="L-398"><a href="#L-398"><span class="linenos">398</span></a><span class="sd">    - Relative jumps: RJMP, RJEQ, RJNE, RJGT, RJGE, RJIF</span>
+</span><span id="L-399"><a href="#L-399"><span class="linenos">399</span></a><span class="sd">    - Function calls: CALL, RCALL</span>
 </span><span id="L-400"><a href="#L-400"><span class="linenos">400</span></a>
-</span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="sd">    Examples</span>
-</span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a><span class="sd">    --------</span>
-</span><span id="L-403"><a href="#L-403"><span class="linenos">403</span></a><span class="sd">    Simple loop counting from 0 to 10:</span>
+</span><span id="L-401"><a href="#L-401"><span class="linenos">401</span></a><span class="sd">    Invalid Usage</span>
+</span><span id="L-402"><a href="#L-402"><span class="linenos">402</span></a><span class="sd">    -------------</span>
+</span><span id="L-403"><a href="#L-403"><span class="linenos">403</span></a><span class="sd">    Labels cannot be used in arithmetic, logic, or other operations:</span>
 </span><span id="L-404"><a href="#L-404"><span class="linenos">404</span></a><span class="sd">    ```python</span>
-</span><span id="L-405"><a href="#L-405"><span class="linenos">405</span></a><span class="sd">    from dt31 import DT31, I, R, L, Label</span>
-</span><span id="L-406"><a href="#L-406"><span class="linenos">406</span></a><span class="sd">    from dt31.assembler import assemble</span>
-</span><span id="L-407"><a href="#L-407"><span class="linenos">407</span></a>
-</span><span id="L-408"><a href="#L-408"><span class="linenos">408</span></a><span class="sd">    loop = Label(&quot;loop&quot;)</span>
-</span><span id="L-409"><a href="#L-409"><span class="linenos">409</span></a><span class="sd">    program = [</span>
-</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a><span class="sd">        I.CP(R.a, L[0]),</span>
-</span><span id="L-411"><a href="#L-411"><span class="linenos">411</span></a><span class="sd">        loop,                          # Mark loop start</span>
-</span><span id="L-412"><a href="#L-412"><span class="linenos">412</span></a><span class="sd">        I.NOUT(R.a, L[1]),             # Print counter</span>
-</span><span id="L-413"><a href="#L-413"><span class="linenos">413</span></a><span class="sd">        I.ADD(R.a, L[1]),              # Increment</span>
-</span><span id="L-414"><a href="#L-414"><span class="linenos">414</span></a><span class="sd">        I.JGT(loop, L[10], R.a),       # Continue if a &lt;= 10</span>
-</span><span id="L-415"><a href="#L-415"><span class="linenos">415</span></a><span class="sd">    ]</span>
+</span><span id="L-405"><a href="#L-405"><span class="linenos">405</span></a><span class="sd">    I.ADD(R.a, Label(&quot;x&quot;))      # INVALID - will cause runtime error</span>
+</span><span id="L-406"><a href="#L-406"><span class="linenos">406</span></a><span class="sd">    I.CP(Label(&quot;foo&quot;), R.b)     # INVALID - will cause runtime error</span>
+</span><span id="L-407"><a href="#L-407"><span class="linenos">407</span></a><span class="sd">    M[Label(&quot;addr&quot;)]            # INVALID - will cause runtime error</span>
+</span><span id="L-408"><a href="#L-408"><span class="linenos">408</span></a><span class="sd">    ```</span>
+</span><span id="L-409"><a href="#L-409"><span class="linenos">409</span></a>
+</span><span id="L-410"><a href="#L-410"><span class="linenos">410</span></a><span class="sd">    Examples</span>
+</span><span id="L-411"><a href="#L-411"><span class="linenos">411</span></a><span class="sd">    --------</span>
+</span><span id="L-412"><a href="#L-412"><span class="linenos">412</span></a><span class="sd">    Simple loop counting from 0 to 10:</span>
+</span><span id="L-413"><a href="#L-413"><span class="linenos">413</span></a><span class="sd">    ```python</span>
+</span><span id="L-414"><a href="#L-414"><span class="linenos">414</span></a><span class="sd">    from dt31 import DT31, I, R, L, Label</span>
+</span><span id="L-415"><a href="#L-415"><span class="linenos">415</span></a><span class="sd">    from dt31.assembler import assemble</span>
 </span><span id="L-416"><a href="#L-416"><span class="linenos">416</span></a>
-</span><span id="L-417"><a href="#L-417"><span class="linenos">417</span></a><span class="sd">    cpu = DT31()</span>
-</span><span id="L-418"><a href="#L-418"><span class="linenos">418</span></a><span class="sd">    cpu.run(assemble(program))</span>
-</span><span id="L-419"><a href="#L-419"><span class="linenos">419</span></a><span class="sd">    ```</span>
-</span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a>
-</span><span id="L-421"><a href="#L-421"><span class="linenos">421</span></a><span class="sd">    Function with label:</span>
-</span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a><span class="sd">    ```python</span>
-</span><span id="L-423"><a href="#L-423"><span class="linenos">423</span></a><span class="sd">    program = [</span>
-</span><span id="L-424"><a href="#L-424"><span class="linenos">424</span></a><span class="sd">        I.CALL(Label(&quot;greet&quot;)),</span>
-</span><span id="L-425"><a href="#L-425"><span class="linenos">425</span></a><span class="sd">        I.JMP(Label(&quot;end&quot;)),</span>
-</span><span id="L-426"><a href="#L-426"><span class="linenos">426</span></a>
-</span><span id="L-427"><a href="#L-427"><span class="linenos">427</span></a><span class="sd">        Label(&quot;greet&quot;),</span>
-</span><span id="L-428"><a href="#L-428"><span class="linenos">428</span></a><span class="sd">        I.COUT(LC[&#39;H&#39;]),</span>
-</span><span id="L-429"><a href="#L-429"><span class="linenos">429</span></a><span class="sd">        I.COUT(LC[&#39;i&#39;]),</span>
-</span><span id="L-430"><a href="#L-430"><span class="linenos">430</span></a><span class="sd">        I.RET(),</span>
-</span><span id="L-431"><a href="#L-431"><span class="linenos">431</span></a>
-</span><span id="L-432"><a href="#L-432"><span class="linenos">432</span></a><span class="sd">        Label(&quot;end&quot;),</span>
-</span><span id="L-433"><a href="#L-433"><span class="linenos">433</span></a><span class="sd">    ]</span>
-</span><span id="L-434"><a href="#L-434"><span class="linenos">434</span></a><span class="sd">    ```</span>
-</span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a>
-</span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="L-438"><a href="#L-438"><span class="linenos">438</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
-</span><span id="L-439"><a href="#L-439"><span class="linenos">439</span></a>
-</span><span id="L-440"><a href="#L-440"><span class="linenos">440</span></a><span class="sd">        Args:</span>
-</span><span id="L-441"><a href="#L-441"><span class="linenos">441</span></a><span class="sd">            name: The symbolic name for this label.</span>
-</span><span id="L-442"><a href="#L-442"><span class="linenos">442</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-443"><a href="#L-443"><span class="linenos">443</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-</span><span id="L-444"><a href="#L-444"><span class="linenos">444</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
+</span><span id="L-417"><a href="#L-417"><span class="linenos">417</span></a><span class="sd">    loop = Label(&quot;loop&quot;)</span>
+</span><span id="L-418"><a href="#L-418"><span class="linenos">418</span></a><span class="sd">    program = [</span>
+</span><span id="L-419"><a href="#L-419"><span class="linenos">419</span></a><span class="sd">        I.CP(R.a, L[0]),</span>
+</span><span id="L-420"><a href="#L-420"><span class="linenos">420</span></a><span class="sd">        loop,                          # Mark loop start</span>
+</span><span id="L-421"><a href="#L-421"><span class="linenos">421</span></a><span class="sd">        I.NOUT(R.a, L[1]),             # Print counter</span>
+</span><span id="L-422"><a href="#L-422"><span class="linenos">422</span></a><span class="sd">        I.ADD(R.a, L[1]),              # Increment</span>
+</span><span id="L-423"><a href="#L-423"><span class="linenos">423</span></a><span class="sd">        I.JGT(loop, L[10], R.a),       # Continue if a &lt;= 10</span>
+</span><span id="L-424"><a href="#L-424"><span class="linenos">424</span></a><span class="sd">    ]</span>
+</span><span id="L-425"><a href="#L-425"><span class="linenos">425</span></a>
+</span><span id="L-426"><a href="#L-426"><span class="linenos">426</span></a><span class="sd">    cpu = DT31()</span>
+</span><span id="L-427"><a href="#L-427"><span class="linenos">427</span></a><span class="sd">    cpu.run(assemble(program))</span>
+</span><span id="L-428"><a href="#L-428"><span class="linenos">428</span></a><span class="sd">    ```</span>
+</span><span id="L-429"><a href="#L-429"><span class="linenos">429</span></a>
+</span><span id="L-430"><a href="#L-430"><span class="linenos">430</span></a><span class="sd">    Function with label:</span>
+</span><span id="L-431"><a href="#L-431"><span class="linenos">431</span></a><span class="sd">    ```python</span>
+</span><span id="L-432"><a href="#L-432"><span class="linenos">432</span></a><span class="sd">    program = [</span>
+</span><span id="L-433"><a href="#L-433"><span class="linenos">433</span></a><span class="sd">        I.CALL(Label(&quot;greet&quot;)),</span>
+</span><span id="L-434"><a href="#L-434"><span class="linenos">434</span></a><span class="sd">        I.JMP(Label(&quot;end&quot;)),</span>
+</span><span id="L-435"><a href="#L-435"><span class="linenos">435</span></a>
+</span><span id="L-436"><a href="#L-436"><span class="linenos">436</span></a><span class="sd">        Label(&quot;greet&quot;),</span>
+</span><span id="L-437"><a href="#L-437"><span class="linenos">437</span></a><span class="sd">        I.COUT(LC[&#39;H&#39;]),</span>
+</span><span id="L-438"><a href="#L-438"><span class="linenos">438</span></a><span class="sd">        I.COUT(LC[&#39;i&#39;]),</span>
+</span><span id="L-439"><a href="#L-439"><span class="linenos">439</span></a><span class="sd">        I.RET(),</span>
+</span><span id="L-440"><a href="#L-440"><span class="linenos">440</span></a>
+</span><span id="L-441"><a href="#L-441"><span class="linenos">441</span></a><span class="sd">        Label(&quot;end&quot;),</span>
+</span><span id="L-442"><a href="#L-442"><span class="linenos">442</span></a><span class="sd">    ]</span>
+</span><span id="L-443"><a href="#L-443"><span class="linenos">443</span></a><span class="sd">    ```</span>
+</span><span id="L-444"><a href="#L-444"><span class="linenos">444</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="L-445"><a href="#L-445"><span class="linenos">445</span></a>
-</span><span id="L-446"><a href="#L-446"><span class="linenos">446</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
+</span><span id="L-446"><a href="#L-446"><span class="linenos">446</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="L-447"><a href="#L-447"><span class="linenos">447</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
 </span><span id="L-448"><a href="#L-448"><span class="linenos">448</span></a>
-</span><span id="L-449"><a href="#L-449"><span class="linenos">449</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
-</span><span id="L-450"><a href="#L-450"><span class="linenos">450</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
-</span><span id="L-451"><a href="#L-451"><span class="linenos">451</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
-</span><span id="L-452"><a href="#L-452"><span class="linenos">452</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
-</span><span id="L-453"><a href="#L-453"><span class="linenos">453</span></a>
-</span><span id="L-454"><a href="#L-454"><span class="linenos">454</span></a><span class="sd">        Args:</span>
-</span><span id="L-455"><a href="#L-455"><span class="linenos">455</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
-</span><span id="L-456"><a href="#L-456"><span class="linenos">456</span></a>
-</span><span id="L-457"><a href="#L-457"><span class="linenos">457</span></a><span class="sd">        Raises:</span>
-</span><span id="L-458"><a href="#L-458"><span class="linenos">458</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
-</span><span id="L-459"><a href="#L-459"><span class="linenos">459</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-460"><a href="#L-460"><span class="linenos">460</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
-</span><span id="L-461"><a href="#L-461"><span class="linenos">461</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
-</span><span id="L-462"><a href="#L-462"><span class="linenos">462</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
-</span><span id="L-463"><a href="#L-463"><span class="linenos">463</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
-</span><span id="L-464"><a href="#L-464"><span class="linenos">464</span></a>        <span class="p">)</span>
+</span><span id="L-449"><a href="#L-449"><span class="linenos">449</span></a><span class="sd">        Args:</span>
+</span><span id="L-450"><a href="#L-450"><span class="linenos">450</span></a><span class="sd">            name: The symbolic name for this label.</span>
+</span><span id="L-451"><a href="#L-451"><span class="linenos">451</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-452"><a href="#L-452"><span class="linenos">452</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="L-453"><a href="#L-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
+</span><span id="L-454"><a href="#L-454"><span class="linenos">454</span></a>
+</span><span id="L-455"><a href="#L-455"><span class="linenos">455</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="L-456"><a href="#L-456"><span class="linenos">456</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
+</span><span id="L-457"><a href="#L-457"><span class="linenos">457</span></a>
+</span><span id="L-458"><a href="#L-458"><span class="linenos">458</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
+</span><span id="L-459"><a href="#L-459"><span class="linenos">459</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
+</span><span id="L-460"><a href="#L-460"><span class="linenos">460</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
+</span><span id="L-461"><a href="#L-461"><span class="linenos">461</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
+</span><span id="L-462"><a href="#L-462"><span class="linenos">462</span></a>
+</span><span id="L-463"><a href="#L-463"><span class="linenos">463</span></a><span class="sd">        Args:</span>
+</span><span id="L-464"><a href="#L-464"><span class="linenos">464</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
 </span><span id="L-465"><a href="#L-465"><span class="linenos">465</span></a>
-</span><span id="L-466"><a href="#L-466"><span class="linenos">466</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-467"><a href="#L-467"><span class="linenos">467</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="L-468"><a href="#L-468"><span class="linenos">468</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
-</span><span id="L-469"><a href="#L-469"><span class="linenos">469</span></a>
-</span><span id="L-470"><a href="#L-470"><span class="linenos">470</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="L-471"><a href="#L-471"><span class="linenos">471</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation (without colon).&quot;&quot;&quot;</span>
-</span><span id="L-472"><a href="#L-472"><span class="linenos">472</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
-</span><span id="L-473"><a href="#L-473"><span class="linenos">473</span></a>
-</span><span id="L-474"><a href="#L-474"><span class="linenos">474</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
-</span><span id="L-475"><a href="#L-475"><span class="linenos">475</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
-</span><span id="L-476"><a href="#L-476"><span class="linenos">476</span></a>
-</span><span id="L-477"><a href="#L-477"><span class="linenos">477</span></a><span class="sd">        Args:</span>
-</span><span id="L-478"><a href="#L-478"><span class="linenos">478</span></a><span class="sd">            text: The comment text to associate with the label.</span>
-</span><span id="L-479"><a href="#L-479"><span class="linenos">479</span></a>
-</span><span id="L-480"><a href="#L-480"><span class="linenos">480</span></a><span class="sd">        Returns:</span>
-</span><span id="L-481"><a href="#L-481"><span class="linenos">481</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
-</span><span id="L-482"><a href="#L-482"><span class="linenos">482</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="L-483"><a href="#L-483"><span class="linenos">483</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-</span><span id="L-484"><a href="#L-484"><span class="linenos">484</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
-</span><span id="L-485"><a href="#L-485"><span class="linenos">485</span></a>        <span class="k">return</span> <span class="n">new_label</span>
-</span><span id="L-486"><a href="#L-486"><span class="linenos">486</span></a>
-</span><span id="L-487"><a href="#L-487"><span class="linenos">487</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
-</span><span id="L-488"><a href="#L-488"><span class="linenos">488</span></a>        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="ow">is</span> <span class="ow">not</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
-</span><span id="L-489"><a href="#L-489"><span class="linenos">489</span></a>            <span class="k">return</span> <span class="kc">False</span>
-</span><span id="L-490"><a href="#L-490"><span class="linenos">490</span></a>        <span class="c1"># Exclude comment from equality check</span>
-</span><span id="L-491"><a href="#L-491"><span class="linenos">491</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
-</span><span id="L-492"><a href="#L-492"><span class="linenos">492</span></a>
-</span><span id="L-493"><a href="#L-493"><span class="linenos">493</span></a>
-</span><span id="L-494"><a href="#L-494"><span class="linenos">494</span></a><span class="c1"># Type alias for jump/call destination operands</span>
-</span><span id="L-495"><a href="#L-495"><span class="linenos">495</span></a><span class="n">Destination</span> <span class="o">=</span> <span class="n">Label</span> <span class="o">|</span> <span class="n">Operand</span> <span class="o">|</span> <span class="nb">int</span>
+</span><span id="L-466"><a href="#L-466"><span class="linenos">466</span></a><span class="sd">        Raises:</span>
+</span><span id="L-467"><a href="#L-467"><span class="linenos">467</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
+</span><span id="L-468"><a href="#L-468"><span class="linenos">468</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-469"><a href="#L-469"><span class="linenos">469</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
+</span><span id="L-470"><a href="#L-470"><span class="linenos">470</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
+</span><span id="L-471"><a href="#L-471"><span class="linenos">471</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
+</span><span id="L-472"><a href="#L-472"><span class="linenos">472</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
+</span><span id="L-473"><a href="#L-473"><span class="linenos">473</span></a>        <span class="p">)</span>
+</span><span id="L-474"><a href="#L-474"><span class="linenos">474</span></a>
+</span><span id="L-475"><a href="#L-475"><span class="linenos">475</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-476"><a href="#L-476"><span class="linenos">476</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="L-477"><a href="#L-477"><span class="linenos">477</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="L-478"><a href="#L-478"><span class="linenos">478</span></a>
+</span><span id="L-479"><a href="#L-479"><span class="linenos">479</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="L-480"><a href="#L-480"><span class="linenos">480</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation (without colon).&quot;&quot;&quot;</span>
+</span><span id="L-481"><a href="#L-481"><span class="linenos">481</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="L-482"><a href="#L-482"><span class="linenos">482</span></a>
+</span><span id="L-483"><a href="#L-483"><span class="linenos">483</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
+</span><span id="L-484"><a href="#L-484"><span class="linenos">484</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
+</span><span id="L-485"><a href="#L-485"><span class="linenos">485</span></a>
+</span><span id="L-486"><a href="#L-486"><span class="linenos">486</span></a><span class="sd">        Args:</span>
+</span><span id="L-487"><a href="#L-487"><span class="linenos">487</span></a><span class="sd">            text: The comment text to associate with the label.</span>
+</span><span id="L-488"><a href="#L-488"><span class="linenos">488</span></a>
+</span><span id="L-489"><a href="#L-489"><span class="linenos">489</span></a><span class="sd">        Returns:</span>
+</span><span id="L-490"><a href="#L-490"><span class="linenos">490</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
+</span><span id="L-491"><a href="#L-491"><span class="linenos">491</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-492"><a href="#L-492"><span class="linenos">492</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="L-493"><a href="#L-493"><span class="linenos">493</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
+</span><span id="L-494"><a href="#L-494"><span class="linenos">494</span></a>        <span class="k">return</span> <span class="n">new_label</span>
+</span><span id="L-495"><a href="#L-495"><span class="linenos">495</span></a>
+</span><span id="L-496"><a href="#L-496"><span class="linenos">496</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+</span><span id="L-497"><a href="#L-497"><span class="linenos">497</span></a>        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="ow">is</span> <span class="ow">not</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
+</span><span id="L-498"><a href="#L-498"><span class="linenos">498</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-499"><a href="#L-499"><span class="linenos">499</span></a>        <span class="c1"># Exclude comment from equality check</span>
+</span><span id="L-500"><a href="#L-500"><span class="linenos">500</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+</span><span id="L-501"><a href="#L-501"><span class="linenos">501</span></a>
+</span><span id="L-502"><a href="#L-502"><span class="linenos">502</span></a>
+</span><span id="L-503"><a href="#L-503"><span class="linenos">503</span></a><span class="c1"># Type alias for jump/call destination operands</span>
+</span><span id="L-504"><a href="#L-504"><span class="linenos">504</span></a><span class="n">Destination</span> <span class="o">=</span> <span class="n">Label</span> <span class="o">|</span> <span class="n">Operand</span> <span class="o">|</span> <span class="nb">int</span>
 </span></pre></div>
 
 
@@ -809,15 +818,24 @@ All operands must implement the resolve method to return their value.</p>
 </span><span id="Literal-68"><a href="#Literal-68"><span class="linenos">68</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
 </span><span id="Literal-69"><a href="#Literal-69"><span class="linenos">69</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
 </span><span id="Literal-70"><a href="#Literal-70"><span class="linenos">70</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">is_char</span><span class="p">:</span>
-</span><span id="Literal-71"><a href="#Literal-71"><span class="linenos">71</span></a>            <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;&#39;</span><span class="si">{</span><span class="nb">chr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span><span class="si">}</span><span class="s2">&#39;&quot;</span>
-</span><span id="Literal-72"><a href="#Literal-72"><span class="linenos">72</span></a>        <span class="k">return</span> <span class="nb">str</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
-</span><span id="Literal-73"><a href="#Literal-73"><span class="linenos">73</span></a>
-</span><span id="Literal-74"><a href="#Literal-74"><span class="linenos">74</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
-</span><span id="Literal-75"><a href="#Literal-75"><span class="linenos">75</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="Literal-76"><a href="#Literal-76"><span class="linenos">76</span></a>            <span class="k">return</span> <span class="n">other</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
-</span><span id="Literal-77"><a href="#Literal-77"><span class="linenos">77</span></a>        <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Literal</span><span class="p">):</span>
-</span><span id="Literal-78"><a href="#Literal-78"><span class="linenos">78</span></a>            <span class="k">return</span> <span class="n">other</span><span class="o">.</span><span class="n">value</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
-</span><span id="Literal-79"><a href="#Literal-79"><span class="linenos">79</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="Literal-71"><a href="#Literal-71"><span class="linenos">71</span></a>            <span class="n">char_str</span> <span class="o">=</span> <span class="nb">chr</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
+</span><span id="Literal-72"><a href="#Literal-72"><span class="linenos">72</span></a>            <span class="c1"># Special case for single quote: repr(&quot;&#39;&quot;) -&gt; &quot;&#39;&quot; (uses double quotes)</span>
+</span><span id="Literal-73"><a href="#Literal-73"><span class="linenos">73</span></a>            <span class="c1"># We need to escape it for our single-quote syntax</span>
+</span><span id="Literal-74"><a href="#Literal-74"><span class="linenos">74</span></a>            <span class="k">if</span> <span class="n">char_str</span> <span class="o">==</span> <span class="s2">&quot;&#39;&quot;</span><span class="p">:</span>
+</span><span id="Literal-75"><a href="#Literal-75"><span class="linenos">75</span></a>                <span class="k">return</span> <span class="sa">r</span><span class="s2">&quot;&#39;\&#39;&#39;&quot;</span>
+</span><span id="Literal-76"><a href="#Literal-76"><span class="linenos">76</span></a>            <span class="c1"># For all other characters, repr() handles escaping correctly</span>
+</span><span id="Literal-77"><a href="#Literal-77"><span class="linenos">77</span></a>            <span class="c1"># repr(&quot;A&quot;) -&gt; &quot;&#39;A&#39;&quot;, repr(&quot;\n&quot;) -&gt; &quot;&#39;\n&#39;&quot;, repr(&quot;\\&quot;) -&gt; &quot;&#39;\\\\&#39;&quot;, etc.</span>
+</span><span id="Literal-78"><a href="#Literal-78"><span class="linenos">78</span></a>            <span class="n">escaped</span> <span class="o">=</span> <span class="nb">repr</span><span class="p">(</span><span class="n">char_str</span><span class="p">)</span>
+</span><span id="Literal-79"><a href="#Literal-79"><span class="linenos">79</span></a>            <span class="c1"># Strip the outer quotes that repr() adds and wrap in single quotes</span>
+</span><span id="Literal-80"><a href="#Literal-80"><span class="linenos">80</span></a>            <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;&#39;</span><span class="si">{</span><span class="n">escaped</span><span class="p">[</span><span class="mi">1</span><span class="p">:</span><span class="o">-</span><span class="mi">1</span><span class="p">]</span><span class="si">}</span><span class="s2">&#39;&quot;</span>
+</span><span id="Literal-81"><a href="#Literal-81"><span class="linenos">81</span></a>        <span class="k">return</span> <span class="nb">str</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">value</span><span class="p">)</span>
+</span><span id="Literal-82"><a href="#Literal-82"><span class="linenos">82</span></a>
+</span><span id="Literal-83"><a href="#Literal-83"><span class="linenos">83</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bool</span><span class="p">:</span>
+</span><span id="Literal-84"><a href="#Literal-84"><span class="linenos">84</span></a>        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="Literal-85"><a href="#Literal-85"><span class="linenos">85</span></a>            <span class="k">return</span> <span class="n">other</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
+</span><span id="Literal-86"><a href="#Literal-86"><span class="linenos">86</span></a>        <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">other</span><span class="p">,</span> <span class="n">Literal</span><span class="p">):</span>
+</span><span id="Literal-87"><a href="#Literal-87"><span class="linenos">87</span></a>            <span class="k">return</span> <span class="n">other</span><span class="o">.</span><span class="n">value</span> <span class="o">==</span> <span class="bp">self</span><span class="o">.</span><span class="n">value</span>
+</span><span id="Literal-88"><a href="#Literal-88"><span class="linenos">88</span></a>        <span class="k">return</span> <span class="kc">False</span>
 </span></pre></div>
 
 
@@ -936,15 +954,15 @@ All operands must implement the resolve method to return their value.</p>
 
     </div>
     <a class="headerlink" href="#L"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a><span class="k">class</span><span class="w"> </span><span class="nc">L</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaLiteral</span><span class="p">):</span>
-</span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating Literal operands using bracket syntax.</span>
-</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a>
-</span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a><span class="sd">    Examples:</span>
-</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a><span class="sd">        L[42]  # Creates Literal(42)</span>
-</span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a><span class="sd">        L[0]   # Creates Literal(0)</span>
-</span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>
-</span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>    <span class="k">pass</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a><span class="k">class</span><span class="w"> </span><span class="nc">L</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaLiteral</span><span class="p">):</span>
+</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating Literal operands using bracket syntax.</span>
+</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>
+</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a><span class="sd">    Examples:</span>
+</span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a><span class="sd">        L[42]  # Creates Literal(42)</span>
+</span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a><span class="sd">        L[0]   # Creates Literal(0)</span>
+</span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>    <span class="k">pass</span>
 </span></pre></div>
 
 
@@ -971,15 +989,15 @@ All operands must implement the resolve method to return their value.</p>
 
     </div>
     <a class="headerlink" href="#LC"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="LC-128"><a href="#LC-128"><span class="linenos">128</span></a><span class="k">class</span><span class="w"> </span><span class="nc">LC</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaCharLiteral</span><span class="p">):</span>
-</span><span id="LC-129"><a href="#LC-129"><span class="linenos">129</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating character Literal operands using bracket syntax.</span>
-</span><span id="LC-130"><a href="#LC-130"><span class="linenos">130</span></a>
-</span><span id="LC-131"><a href="#LC-131"><span class="linenos">131</span></a><span class="sd">    Examples:</span>
-</span><span id="LC-132"><a href="#LC-132"><span class="linenos">132</span></a><span class="sd">        LC[&#39;A&#39;]  # Creates Literal(65)</span>
-</span><span id="LC-133"><a href="#LC-133"><span class="linenos">133</span></a><span class="sd">        LC[&#39;z&#39;]  # Creates Literal(122)</span>
-</span><span id="LC-134"><a href="#LC-134"><span class="linenos">134</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="LC-135"><a href="#LC-135"><span class="linenos">135</span></a>
-</span><span id="LC-136"><a href="#LC-136"><span class="linenos">136</span></a>    <span class="k">pass</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="LC-137"><a href="#LC-137"><span class="linenos">137</span></a><span class="k">class</span><span class="w"> </span><span class="nc">LC</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaCharLiteral</span><span class="p">):</span>
+</span><span id="LC-138"><a href="#LC-138"><span class="linenos">138</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating character Literal operands using bracket syntax.</span>
+</span><span id="LC-139"><a href="#LC-139"><span class="linenos">139</span></a>
+</span><span id="LC-140"><a href="#LC-140"><span class="linenos">140</span></a><span class="sd">    Examples:</span>
+</span><span id="LC-141"><a href="#LC-141"><span class="linenos">141</span></a><span class="sd">        LC[&#39;A&#39;]  # Creates Literal(65)</span>
+</span><span id="LC-142"><a href="#LC-142"><span class="linenos">142</span></a><span class="sd">        LC[&#39;z&#39;]  # Creates Literal(122)</span>
+</span><span id="LC-143"><a href="#LC-143"><span class="linenos">143</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="LC-144"><a href="#LC-144"><span class="linenos">144</span></a>
+</span><span id="LC-145"><a href="#LC-145"><span class="linenos">145</span></a>    <span class="k">pass</span>
 </span></pre></div>
 
 
@@ -1006,51 +1024,51 @@ All operands must implement the resolve method to return their value.</p>
 
     </div>
     <a class="headerlink" href="#MemoryReference"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference-139"><a href="#MemoryReference-139"><span class="linenos">139</span></a><span class="k">class</span><span class="w"> </span><span class="nc">MemoryReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
-</span><span id="MemoryReference-140"><a href="#MemoryReference-140"><span class="linenos">140</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a memory address reference.</span>
-</span><span id="MemoryReference-141"><a href="#MemoryReference-141"><span class="linenos">141</span></a>
-</span><span id="MemoryReference-142"><a href="#MemoryReference-142"><span class="linenos">142</span></a><span class="sd">    Memory references resolve to the value stored at a memory address.</span>
-</span><span id="MemoryReference-143"><a href="#MemoryReference-143"><span class="linenos">143</span></a><span class="sd">    The address itself can be a constant or another operand (indirect addressing).</span>
-</span><span id="MemoryReference-144"><a href="#MemoryReference-144"><span class="linenos">144</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="MemoryReference-145"><a href="#MemoryReference-145"><span class="linenos">145</span></a>
-</span><span id="MemoryReference-146"><a href="#MemoryReference-146"><span class="linenos">146</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="MemoryReference-147"><a href="#MemoryReference-147"><span class="linenos">147</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
-</span><span id="MemoryReference-148"><a href="#MemoryReference-148"><span class="linenos">148</span></a>
-</span><span id="MemoryReference-149"><a href="#MemoryReference-149"><span class="linenos">149</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference-150"><a href="#MemoryReference-150"><span class="linenos">150</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
-</span><span id="MemoryReference-151"><a href="#MemoryReference-151"><span class="linenos">151</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
-</span><span id="MemoryReference-152"><a href="#MemoryReference-152"><span class="linenos">152</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference-153"><a href="#MemoryReference-153"><span class="linenos">153</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference-148"><a href="#MemoryReference-148"><span class="linenos">148</span></a><span class="k">class</span><span class="w"> </span><span class="nc">MemoryReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
+</span><span id="MemoryReference-149"><a href="#MemoryReference-149"><span class="linenos">149</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a memory address reference.</span>
+</span><span id="MemoryReference-150"><a href="#MemoryReference-150"><span class="linenos">150</span></a>
+</span><span id="MemoryReference-151"><a href="#MemoryReference-151"><span class="linenos">151</span></a><span class="sd">    Memory references resolve to the value stored at a memory address.</span>
+</span><span id="MemoryReference-152"><a href="#MemoryReference-152"><span class="linenos">152</span></a><span class="sd">    The address itself can be a constant or another operand (indirect addressing).</span>
+</span><span id="MemoryReference-153"><a href="#MemoryReference-153"><span class="linenos">153</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="MemoryReference-154"><a href="#MemoryReference-154"><span class="linenos">154</span></a>
-</span><span id="MemoryReference-155"><a href="#MemoryReference-155"><span class="linenos">155</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="MemoryReference-156"><a href="#MemoryReference-156"><span class="linenos">156</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
+</span><span id="MemoryReference-155"><a href="#MemoryReference-155"><span class="linenos">155</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="MemoryReference-156"><a href="#MemoryReference-156"><span class="linenos">156</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
 </span><span id="MemoryReference-157"><a href="#MemoryReference-157"><span class="linenos">157</span></a>
 </span><span id="MemoryReference-158"><a href="#MemoryReference-158"><span class="linenos">158</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference-159"><a href="#MemoryReference-159"><span class="linenos">159</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
-</span><span id="MemoryReference-160"><a href="#MemoryReference-160"><span class="linenos">160</span></a>
-</span><span id="MemoryReference-161"><a href="#MemoryReference-161"><span class="linenos">161</span></a><span class="sd">        Returns:</span>
-</span><span id="MemoryReference-162"><a href="#MemoryReference-162"><span class="linenos">162</span></a><span class="sd">            The value stored at the resolved memory address.</span>
-</span><span id="MemoryReference-163"><a href="#MemoryReference-163"><span class="linenos">163</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference-164"><a href="#MemoryReference-164"><span class="linenos">164</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
-</span><span id="MemoryReference-165"><a href="#MemoryReference-165"><span class="linenos">165</span></a>
-</span><span id="MemoryReference-166"><a href="#MemoryReference-166"><span class="linenos">166</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="MemoryReference-167"><a href="#MemoryReference-167"><span class="linenos">167</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
-</span><span id="MemoryReference-168"><a href="#MemoryReference-168"><span class="linenos">168</span></a>
-</span><span id="MemoryReference-169"><a href="#MemoryReference-169"><span class="linenos">169</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference-170"><a href="#MemoryReference-170"><span class="linenos">170</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
-</span><span id="MemoryReference-171"><a href="#MemoryReference-171"><span class="linenos">171</span></a>
-</span><span id="MemoryReference-172"><a href="#MemoryReference-172"><span class="linenos">172</span></a><span class="sd">        Returns:</span>
-</span><span id="MemoryReference-173"><a href="#MemoryReference-173"><span class="linenos">173</span></a><span class="sd">            The integer memory address.</span>
-</span><span id="MemoryReference-174"><a href="#MemoryReference-174"><span class="linenos">174</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference-175"><a href="#MemoryReference-175"><span class="linenos">175</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
-</span><span id="MemoryReference-176"><a href="#MemoryReference-176"><span class="linenos">176</span></a>
-</span><span id="MemoryReference-177"><a href="#MemoryReference-177"><span class="linenos">177</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="MemoryReference-178"><a href="#MemoryReference-178"><span class="linenos">178</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="MemoryReference-179"><a href="#MemoryReference-179"><span class="linenos">179</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;M[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">!r}</span><span class="s2">]&quot;</span>
+</span><span id="MemoryReference-159"><a href="#MemoryReference-159"><span class="linenos">159</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
+</span><span id="MemoryReference-160"><a href="#MemoryReference-160"><span class="linenos">160</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
+</span><span id="MemoryReference-161"><a href="#MemoryReference-161"><span class="linenos">161</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference-162"><a href="#MemoryReference-162"><span class="linenos">162</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
+</span><span id="MemoryReference-163"><a href="#MemoryReference-163"><span class="linenos">163</span></a>
+</span><span id="MemoryReference-164"><a href="#MemoryReference-164"><span class="linenos">164</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="MemoryReference-165"><a href="#MemoryReference-165"><span class="linenos">165</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
+</span><span id="MemoryReference-166"><a href="#MemoryReference-166"><span class="linenos">166</span></a>
+</span><span id="MemoryReference-167"><a href="#MemoryReference-167"><span class="linenos">167</span></a><span class="sd">        Args:</span>
+</span><span id="MemoryReference-168"><a href="#MemoryReference-168"><span class="linenos">168</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
+</span><span id="MemoryReference-169"><a href="#MemoryReference-169"><span class="linenos">169</span></a>
+</span><span id="MemoryReference-170"><a href="#MemoryReference-170"><span class="linenos">170</span></a><span class="sd">        Returns:</span>
+</span><span id="MemoryReference-171"><a href="#MemoryReference-171"><span class="linenos">171</span></a><span class="sd">            The value stored at the resolved memory address.</span>
+</span><span id="MemoryReference-172"><a href="#MemoryReference-172"><span class="linenos">172</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference-173"><a href="#MemoryReference-173"><span class="linenos">173</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
+</span><span id="MemoryReference-174"><a href="#MemoryReference-174"><span class="linenos">174</span></a>
+</span><span id="MemoryReference-175"><a href="#MemoryReference-175"><span class="linenos">175</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="MemoryReference-176"><a href="#MemoryReference-176"><span class="linenos">176</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
+</span><span id="MemoryReference-177"><a href="#MemoryReference-177"><span class="linenos">177</span></a>
+</span><span id="MemoryReference-178"><a href="#MemoryReference-178"><span class="linenos">178</span></a><span class="sd">        Args:</span>
+</span><span id="MemoryReference-179"><a href="#MemoryReference-179"><span class="linenos">179</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
 </span><span id="MemoryReference-180"><a href="#MemoryReference-180"><span class="linenos">180</span></a>
-</span><span id="MemoryReference-181"><a href="#MemoryReference-181"><span class="linenos">181</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="MemoryReference-182"><a href="#MemoryReference-182"><span class="linenos">182</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
-</span><span id="MemoryReference-183"><a href="#MemoryReference-183"><span class="linenos">183</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">}</span><span class="s2">]&quot;</span>
+</span><span id="MemoryReference-181"><a href="#MemoryReference-181"><span class="linenos">181</span></a><span class="sd">        Returns:</span>
+</span><span id="MemoryReference-182"><a href="#MemoryReference-182"><span class="linenos">182</span></a><span class="sd">            The integer memory address.</span>
+</span><span id="MemoryReference-183"><a href="#MemoryReference-183"><span class="linenos">183</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference-184"><a href="#MemoryReference-184"><span class="linenos">184</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
+</span><span id="MemoryReference-185"><a href="#MemoryReference-185"><span class="linenos">185</span></a>
+</span><span id="MemoryReference-186"><a href="#MemoryReference-186"><span class="linenos">186</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="MemoryReference-187"><a href="#MemoryReference-187"><span class="linenos">187</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="MemoryReference-188"><a href="#MemoryReference-188"><span class="linenos">188</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;M[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">!r}</span><span class="s2">]&quot;</span>
+</span><span id="MemoryReference-189"><a href="#MemoryReference-189"><span class="linenos">189</span></a>
+</span><span id="MemoryReference-190"><a href="#MemoryReference-190"><span class="linenos">190</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="MemoryReference-191"><a href="#MemoryReference-191"><span class="linenos">191</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
+</span><span id="MemoryReference-192"><a href="#MemoryReference-192"><span class="linenos">192</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;[</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="si">}</span><span class="s2">]&quot;</span>
 </span></pre></div>
 
 
@@ -1071,14 +1089,14 @@ The address itself can be a constant or another operand (indirect addressing).</
 
     </div>
     <a class="headerlink" href="#MemoryReference.__init__"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.__init__-146"><a href="#MemoryReference.__init__-146"><span class="linenos">146</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="MemoryReference.__init__-147"><a href="#MemoryReference.__init__-147"><span class="linenos">147</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
-</span><span id="MemoryReference.__init__-148"><a href="#MemoryReference.__init__-148"><span class="linenos">148</span></a>
-</span><span id="MemoryReference.__init__-149"><a href="#MemoryReference.__init__-149"><span class="linenos">149</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference.__init__-150"><a href="#MemoryReference.__init__-150"><span class="linenos">150</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
-</span><span id="MemoryReference.__init__-151"><a href="#MemoryReference.__init__-151"><span class="linenos">151</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
-</span><span id="MemoryReference.__init__-152"><a href="#MemoryReference.__init__-152"><span class="linenos">152</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference.__init__-153"><a href="#MemoryReference.__init__-153"><span class="linenos">153</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.__init__-155"><a href="#MemoryReference.__init__-155"><span class="linenos">155</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">address</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="MemoryReference.__init__-156"><a href="#MemoryReference.__init__-156"><span class="linenos">156</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a memory reference operand.</span>
+</span><span id="MemoryReference.__init__-157"><a href="#MemoryReference.__init__-157"><span class="linenos">157</span></a>
+</span><span id="MemoryReference.__init__-158"><a href="#MemoryReference.__init__-158"><span class="linenos">158</span></a><span class="sd">        Args:</span>
+</span><span id="MemoryReference.__init__-159"><a href="#MemoryReference.__init__-159"><span class="linenos">159</span></a><span class="sd">            address: The memory address, either as an integer literal or reference that</span>
+</span><span id="MemoryReference.__init__-160"><a href="#MemoryReference.__init__-160"><span class="linenos">160</span></a><span class="sd">                resolves to an address (for indirect addressing).</span>
+</span><span id="MemoryReference.__init__-161"><a href="#MemoryReference.__init__-161"><span class="linenos">161</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference.__init__-162"><a href="#MemoryReference.__init__-162"><span class="linenos">162</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">address</span> <span class="o">=</span> <span class="n">as_op</span><span class="p">(</span><span class="n">address</span><span class="p">)</span>
 </span></pre></div>
 
 
@@ -1116,16 +1134,16 @@ resolves to an address (for indirect addressing).</li>
 
     </div>
     <a class="headerlink" href="#MemoryReference.resolve"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.resolve-155"><a href="#MemoryReference.resolve-155"><span class="linenos">155</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="MemoryReference.resolve-156"><a href="#MemoryReference.resolve-156"><span class="linenos">156</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
-</span><span id="MemoryReference.resolve-157"><a href="#MemoryReference.resolve-157"><span class="linenos">157</span></a>
-</span><span id="MemoryReference.resolve-158"><a href="#MemoryReference.resolve-158"><span class="linenos">158</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference.resolve-159"><a href="#MemoryReference.resolve-159"><span class="linenos">159</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
-</span><span id="MemoryReference.resolve-160"><a href="#MemoryReference.resolve-160"><span class="linenos">160</span></a>
-</span><span id="MemoryReference.resolve-161"><a href="#MemoryReference.resolve-161"><span class="linenos">161</span></a><span class="sd">        Returns:</span>
-</span><span id="MemoryReference.resolve-162"><a href="#MemoryReference.resolve-162"><span class="linenos">162</span></a><span class="sd">            The value stored at the resolved memory address.</span>
-</span><span id="MemoryReference.resolve-163"><a href="#MemoryReference.resolve-163"><span class="linenos">163</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference.resolve-164"><a href="#MemoryReference.resolve-164"><span class="linenos">164</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.resolve-164"><a href="#MemoryReference.resolve-164"><span class="linenos">164</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="MemoryReference.resolve-165"><a href="#MemoryReference.resolve-165"><span class="linenos">165</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the memory reference to the value at its address.</span>
+</span><span id="MemoryReference.resolve-166"><a href="#MemoryReference.resolve-166"><span class="linenos">166</span></a>
+</span><span id="MemoryReference.resolve-167"><a href="#MemoryReference.resolve-167"><span class="linenos">167</span></a><span class="sd">        Args:</span>
+</span><span id="MemoryReference.resolve-168"><a href="#MemoryReference.resolve-168"><span class="linenos">168</span></a><span class="sd">            cpu: The DT31 CPU instance providing memory access.</span>
+</span><span id="MemoryReference.resolve-169"><a href="#MemoryReference.resolve-169"><span class="linenos">169</span></a>
+</span><span id="MemoryReference.resolve-170"><a href="#MemoryReference.resolve-170"><span class="linenos">170</span></a><span class="sd">        Returns:</span>
+</span><span id="MemoryReference.resolve-171"><a href="#MemoryReference.resolve-171"><span class="linenos">171</span></a><span class="sd">            The value stored at the resolved memory address.</span>
+</span><span id="MemoryReference.resolve-172"><a href="#MemoryReference.resolve-172"><span class="linenos">172</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference.resolve-173"><a href="#MemoryReference.resolve-173"><span class="linenos">173</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_memory</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">resolve_address</span><span class="p">(</span><span class="n">cpu</span><span class="p">))</span>
 </span></pre></div>
 
 
@@ -1157,16 +1175,16 @@ resolves to an address (for indirect addressing).</li>
 
     </div>
     <a class="headerlink" href="#MemoryReference.resolve_address"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.resolve_address-166"><a href="#MemoryReference.resolve_address-166"><span class="linenos">166</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="MemoryReference.resolve_address-167"><a href="#MemoryReference.resolve_address-167"><span class="linenos">167</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
-</span><span id="MemoryReference.resolve_address-168"><a href="#MemoryReference.resolve_address-168"><span class="linenos">168</span></a>
-</span><span id="MemoryReference.resolve_address-169"><a href="#MemoryReference.resolve_address-169"><span class="linenos">169</span></a><span class="sd">        Args:</span>
-</span><span id="MemoryReference.resolve_address-170"><a href="#MemoryReference.resolve_address-170"><span class="linenos">170</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
-</span><span id="MemoryReference.resolve_address-171"><a href="#MemoryReference.resolve_address-171"><span class="linenos">171</span></a>
-</span><span id="MemoryReference.resolve_address-172"><a href="#MemoryReference.resolve_address-172"><span class="linenos">172</span></a><span class="sd">        Returns:</span>
-</span><span id="MemoryReference.resolve_address-173"><a href="#MemoryReference.resolve_address-173"><span class="linenos">173</span></a><span class="sd">            The integer memory address.</span>
-</span><span id="MemoryReference.resolve_address-174"><a href="#MemoryReference.resolve_address-174"><span class="linenos">174</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="MemoryReference.resolve_address-175"><a href="#MemoryReference.resolve_address-175"><span class="linenos">175</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="MemoryReference.resolve_address-175"><a href="#MemoryReference.resolve_address-175"><span class="linenos">175</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve_address</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="MemoryReference.resolve_address-176"><a href="#MemoryReference.resolve_address-176"><span class="linenos">176</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the address of this memory reference.</span>
+</span><span id="MemoryReference.resolve_address-177"><a href="#MemoryReference.resolve_address-177"><span class="linenos">177</span></a>
+</span><span id="MemoryReference.resolve_address-178"><a href="#MemoryReference.resolve_address-178"><span class="linenos">178</span></a><span class="sd">        Args:</span>
+</span><span id="MemoryReference.resolve_address-179"><a href="#MemoryReference.resolve_address-179"><span class="linenos">179</span></a><span class="sd">            cpu: The DT31 CPU instance for resolving operand addresses.</span>
+</span><span id="MemoryReference.resolve_address-180"><a href="#MemoryReference.resolve_address-180"><span class="linenos">180</span></a>
+</span><span id="MemoryReference.resolve_address-181"><a href="#MemoryReference.resolve_address-181"><span class="linenos">181</span></a><span class="sd">        Returns:</span>
+</span><span id="MemoryReference.resolve_address-182"><a href="#MemoryReference.resolve_address-182"><span class="linenos">182</span></a><span class="sd">            The integer memory address.</span>
+</span><span id="MemoryReference.resolve_address-183"><a href="#MemoryReference.resolve_address-183"><span class="linenos">183</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="MemoryReference.resolve_address-184"><a href="#MemoryReference.resolve_address-184"><span class="linenos">184</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">address</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="n">cpu</span><span class="p">)</span>
 </span></pre></div>
 
 
@@ -1199,16 +1217,16 @@ resolves to an address (for indirect addressing).</li>
 
     </div>
     <a class="headerlink" href="#M"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="M-201"><a href="#M-201"><span class="linenos">201</span></a><span class="k">class</span><span class="w"> </span><span class="nc">M</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaMemory</span><span class="p">):</span>
-</span><span id="M-202"><a href="#M-202"><span class="linenos">202</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating MemoryReference operands using bracket syntax.</span>
-</span><span id="M-203"><a href="#M-203"><span class="linenos">203</span></a>
-</span><span id="M-204"><a href="#M-204"><span class="linenos">204</span></a><span class="sd">    Examples:</span>
-</span><span id="M-205"><a href="#M-205"><span class="linenos">205</span></a><span class="sd">        M[100]      # Direct memory access at address 100</span>
-</span><span id="M-206"><a href="#M-206"><span class="linenos">206</span></a><span class="sd">        M[R.a]      # Indirect memory access using register &#39;a&#39; as address</span>
-</span><span id="M-207"><a href="#M-207"><span class="linenos">207</span></a><span class="sd">        M[M[50]]    # Double indirect addressing</span>
-</span><span id="M-208"><a href="#M-208"><span class="linenos">208</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="M-209"><a href="#M-209"><span class="linenos">209</span></a>
-</span><span id="M-210"><a href="#M-210"><span class="linenos">210</span></a>    <span class="k">pass</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="M-210"><a href="#M-210"><span class="linenos">210</span></a><span class="k">class</span><span class="w"> </span><span class="nc">M</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaMemory</span><span class="p">):</span>
+</span><span id="M-211"><a href="#M-211"><span class="linenos">211</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating MemoryReference operands using bracket syntax.</span>
+</span><span id="M-212"><a href="#M-212"><span class="linenos">212</span></a>
+</span><span id="M-213"><a href="#M-213"><span class="linenos">213</span></a><span class="sd">    Examples:</span>
+</span><span id="M-214"><a href="#M-214"><span class="linenos">214</span></a><span class="sd">        M[100]      # Direct memory access at address 100</span>
+</span><span id="M-215"><a href="#M-215"><span class="linenos">215</span></a><span class="sd">        M[R.a]      # Indirect memory access using register &#39;a&#39; as address</span>
+</span><span id="M-216"><a href="#M-216"><span class="linenos">216</span></a><span class="sd">        M[M[50]]    # Double indirect addressing</span>
+</span><span id="M-217"><a href="#M-217"><span class="linenos">217</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="M-218"><a href="#M-218"><span class="linenos">218</span></a>
+</span><span id="M-219"><a href="#M-219"><span class="linenos">219</span></a>    <span class="k">pass</span>
 </span></pre></div>
 
 
@@ -1236,39 +1254,39 @@ resolves to an address (for indirect addressing).</li>
 
     </div>
     <a class="headerlink" href="#validate_register_name"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="validate_register_name-213"><a href="#validate_register_name-213"><span class="linenos">213</span></a><span class="k">def</span><span class="w"> </span><span class="nf">validate_register_name</span><span class="p">(</span><span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
-</span><span id="validate_register_name-214"><a href="#validate_register_name-214"><span class="linenos">214</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Validate that a register name is a valid Python identifier.</span>
-</span><span id="validate_register_name-215"><a href="#validate_register_name-215"><span class="linenos">215</span></a>
-</span><span id="validate_register_name-216"><a href="#validate_register_name-216"><span class="linenos">216</span></a><span class="sd">    Register names must be valid Python identifiers and cannot start with</span>
-</span><span id="validate_register_name-217"><a href="#validate_register_name-217"><span class="linenos">217</span></a><span class="sd">    double underscores to avoid conflicts with dunder methods.</span>
-</span><span id="validate_register_name-218"><a href="#validate_register_name-218"><span class="linenos">218</span></a>
-</span><span id="validate_register_name-219"><a href="#validate_register_name-219"><span class="linenos">219</span></a><span class="sd">    Args:</span>
-</span><span id="validate_register_name-220"><a href="#validate_register_name-220"><span class="linenos">220</span></a><span class="sd">        name: The register name to validate.</span>
-</span><span id="validate_register_name-221"><a href="#validate_register_name-221"><span class="linenos">221</span></a>
-</span><span id="validate_register_name-222"><a href="#validate_register_name-222"><span class="linenos">222</span></a><span class="sd">    Raises:</span>
-</span><span id="validate_register_name-223"><a href="#validate_register_name-223"><span class="linenos">223</span></a><span class="sd">        ValueError: If the register name is not a valid Python identifier</span>
-</span><span id="validate_register_name-224"><a href="#validate_register_name-224"><span class="linenos">224</span></a><span class="sd">            or starts with double underscores.</span>
-</span><span id="validate_register_name-225"><a href="#validate_register_name-225"><span class="linenos">225</span></a>
-</span><span id="validate_register_name-226"><a href="#validate_register_name-226"><span class="linenos">226</span></a><span class="sd">    Examples:</span>
-</span><span id="validate_register_name-227"><a href="#validate_register_name-227"><span class="linenos">227</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;a&quot;)  # Valid</span>
-</span><span id="validate_register_name-228"><a href="#validate_register_name-228"><span class="linenos">228</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my_reg&quot;)  # Valid</span>
-</span><span id="validate_register_name-229"><a href="#validate_register_name-229"><span class="linenos">229</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;reg123&quot;)  # Valid</span>
-</span><span id="validate_register_name-230"><a href="#validate_register_name-230"><span class="linenos">230</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;_private&quot;)  # Valid</span>
-</span><span id="validate_register_name-231"><a href="#validate_register_name-231"><span class="linenos">231</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;123&quot;)  # Raises ValueError</span>
-</span><span id="validate_register_name-232"><a href="#validate_register_name-232"><span class="linenos">232</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my-reg&quot;)  # Raises ValueError</span>
-</span><span id="validate_register_name-233"><a href="#validate_register_name-233"><span class="linenos">233</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;__dunder__&quot;)  # Raises ValueError</span>
-</span><span id="validate_register_name-234"><a href="#validate_register_name-234"><span class="linenos">234</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="validate_register_name-235"><a href="#validate_register_name-235"><span class="linenos">235</span></a>    <span class="k">if</span> <span class="ow">not</span> <span class="n">name</span><span class="o">.</span><span class="n">isidentifier</span><span class="p">():</span>
-</span><span id="validate_register_name-236"><a href="#validate_register_name-236"><span class="linenos">236</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
-</span><span id="validate_register_name-237"><a href="#validate_register_name-237"><span class="linenos">237</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
-</span><span id="validate_register_name-238"><a href="#validate_register_name-238"><span class="linenos">238</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names must be valid Python identifiers &quot;</span>
-</span><span id="validate_register_name-239"><a href="#validate_register_name-239"><span class="linenos">239</span></a>            <span class="sa">f</span><span class="s2">&quot;(letters, digits, underscores; cannot start with a digit).&quot;</span>
-</span><span id="validate_register_name-240"><a href="#validate_register_name-240"><span class="linenos">240</span></a>        <span class="p">)</span>
-</span><span id="validate_register_name-241"><a href="#validate_register_name-241"><span class="linenos">241</span></a>    <span class="k">if</span> <span class="n">name</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
-</span><span id="validate_register_name-242"><a href="#validate_register_name-242"><span class="linenos">242</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
-</span><span id="validate_register_name-243"><a href="#validate_register_name-243"><span class="linenos">243</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
-</span><span id="validate_register_name-244"><a href="#validate_register_name-244"><span class="linenos">244</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names cannot start with double underscores (reserved for dunder methods).&quot;</span>
-</span><span id="validate_register_name-245"><a href="#validate_register_name-245"><span class="linenos">245</span></a>        <span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="validate_register_name-222"><a href="#validate_register_name-222"><span class="linenos">222</span></a><span class="k">def</span><span class="w"> </span><span class="nf">validate_register_name</span><span class="p">(</span><span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="validate_register_name-223"><a href="#validate_register_name-223"><span class="linenos">223</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Validate that a register name is a valid Python identifier.</span>
+</span><span id="validate_register_name-224"><a href="#validate_register_name-224"><span class="linenos">224</span></a>
+</span><span id="validate_register_name-225"><a href="#validate_register_name-225"><span class="linenos">225</span></a><span class="sd">    Register names must be valid Python identifiers and cannot start with</span>
+</span><span id="validate_register_name-226"><a href="#validate_register_name-226"><span class="linenos">226</span></a><span class="sd">    double underscores to avoid conflicts with dunder methods.</span>
+</span><span id="validate_register_name-227"><a href="#validate_register_name-227"><span class="linenos">227</span></a>
+</span><span id="validate_register_name-228"><a href="#validate_register_name-228"><span class="linenos">228</span></a><span class="sd">    Args:</span>
+</span><span id="validate_register_name-229"><a href="#validate_register_name-229"><span class="linenos">229</span></a><span class="sd">        name: The register name to validate.</span>
+</span><span id="validate_register_name-230"><a href="#validate_register_name-230"><span class="linenos">230</span></a>
+</span><span id="validate_register_name-231"><a href="#validate_register_name-231"><span class="linenos">231</span></a><span class="sd">    Raises:</span>
+</span><span id="validate_register_name-232"><a href="#validate_register_name-232"><span class="linenos">232</span></a><span class="sd">        ValueError: If the register name is not a valid Python identifier</span>
+</span><span id="validate_register_name-233"><a href="#validate_register_name-233"><span class="linenos">233</span></a><span class="sd">            or starts with double underscores.</span>
+</span><span id="validate_register_name-234"><a href="#validate_register_name-234"><span class="linenos">234</span></a>
+</span><span id="validate_register_name-235"><a href="#validate_register_name-235"><span class="linenos">235</span></a><span class="sd">    Examples:</span>
+</span><span id="validate_register_name-236"><a href="#validate_register_name-236"><span class="linenos">236</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;a&quot;)  # Valid</span>
+</span><span id="validate_register_name-237"><a href="#validate_register_name-237"><span class="linenos">237</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my_reg&quot;)  # Valid</span>
+</span><span id="validate_register_name-238"><a href="#validate_register_name-238"><span class="linenos">238</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;reg123&quot;)  # Valid</span>
+</span><span id="validate_register_name-239"><a href="#validate_register_name-239"><span class="linenos">239</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;_private&quot;)  # Valid</span>
+</span><span id="validate_register_name-240"><a href="#validate_register_name-240"><span class="linenos">240</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;123&quot;)  # Raises ValueError</span>
+</span><span id="validate_register_name-241"><a href="#validate_register_name-241"><span class="linenos">241</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;my-reg&quot;)  # Raises ValueError</span>
+</span><span id="validate_register_name-242"><a href="#validate_register_name-242"><span class="linenos">242</span></a><span class="sd">        &gt;&gt;&gt; validate_register_name(&quot;__dunder__&quot;)  # Raises ValueError</span>
+</span><span id="validate_register_name-243"><a href="#validate_register_name-243"><span class="linenos">243</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="validate_register_name-244"><a href="#validate_register_name-244"><span class="linenos">244</span></a>    <span class="k">if</span> <span class="ow">not</span> <span class="n">name</span><span class="o">.</span><span class="n">isidentifier</span><span class="p">():</span>
+</span><span id="validate_register_name-245"><a href="#validate_register_name-245"><span class="linenos">245</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
+</span><span id="validate_register_name-246"><a href="#validate_register_name-246"><span class="linenos">246</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
+</span><span id="validate_register_name-247"><a href="#validate_register_name-247"><span class="linenos">247</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names must be valid Python identifiers &quot;</span>
+</span><span id="validate_register_name-248"><a href="#validate_register_name-248"><span class="linenos">248</span></a>            <span class="sa">f</span><span class="s2">&quot;(letters, digits, underscores; cannot start with a digit).&quot;</span>
+</span><span id="validate_register_name-249"><a href="#validate_register_name-249"><span class="linenos">249</span></a>        <span class="p">)</span>
+</span><span id="validate_register_name-250"><a href="#validate_register_name-250"><span class="linenos">250</span></a>    <span class="k">if</span> <span class="n">name</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;__&quot;</span><span class="p">):</span>
+</span><span id="validate_register_name-251"><a href="#validate_register_name-251"><span class="linenos">251</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span>
+</span><span id="validate_register_name-252"><a href="#validate_register_name-252"><span class="linenos">252</span></a>            <span class="sa">f</span><span class="s2">&quot;Invalid register name &#39;</span><span class="si">{</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39;. &quot;</span>
+</span><span id="validate_register_name-253"><a href="#validate_register_name-253"><span class="linenos">253</span></a>            <span class="sa">f</span><span class="s2">&quot;Register names cannot start with double underscores (reserved for dunder methods).&quot;</span>
+</span><span id="validate_register_name-254"><a href="#validate_register_name-254"><span class="linenos">254</span></a>        <span class="p">)</span>
 </span></pre></div>
 
 
@@ -1319,48 +1337,48 @@ or starts with double underscores.</li>
 
     </div>
     <a class="headerlink" href="#RegisterReference"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference-248"><a href="#RegisterReference-248"><span class="linenos">248</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RegisterReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
-</span><span id="RegisterReference-249"><a href="#RegisterReference-249"><span class="linenos">249</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a CPU register reference.</span>
-</span><span id="RegisterReference-250"><a href="#RegisterReference-250"><span class="linenos">250</span></a>
-</span><span id="RegisterReference-251"><a href="#RegisterReference-251"><span class="linenos">251</span></a><span class="sd">    Register references resolve to the value stored in the named register.</span>
-</span><span id="RegisterReference-252"><a href="#RegisterReference-252"><span class="linenos">252</span></a>
-</span><span id="RegisterReference-253"><a href="#RegisterReference-253"><span class="linenos">253</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
-</span><span id="RegisterReference-254"><a href="#RegisterReference-254"><span class="linenos">254</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
-</span><span id="RegisterReference-255"><a href="#RegisterReference-255"><span class="linenos">255</span></a><span class="sd">    for dunder methods).</span>
-</span><span id="RegisterReference-256"><a href="#RegisterReference-256"><span class="linenos">256</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="RegisterReference-257"><a href="#RegisterReference-257"><span class="linenos">257</span></a>
-</span><span id="RegisterReference-258"><a href="#RegisterReference-258"><span class="linenos">258</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="RegisterReference-259"><a href="#RegisterReference-259"><span class="linenos">259</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
-</span><span id="RegisterReference-260"><a href="#RegisterReference-260"><span class="linenos">260</span></a>
-</span><span id="RegisterReference-261"><a href="#RegisterReference-261"><span class="linenos">261</span></a><span class="sd">        Args:</span>
-</span><span id="RegisterReference-262"><a href="#RegisterReference-262"><span class="linenos">262</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
-</span><span id="RegisterReference-263"><a href="#RegisterReference-263"><span class="linenos">263</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
-</span><span id="RegisterReference-264"><a href="#RegisterReference-264"><span class="linenos">264</span></a>
-</span><span id="RegisterReference-265"><a href="#RegisterReference-265"><span class="linenos">265</span></a><span class="sd">        Raises:</span>
-</span><span id="RegisterReference-266"><a href="#RegisterReference-266"><span class="linenos">266</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
-</span><span id="RegisterReference-267"><a href="#RegisterReference-267"><span class="linenos">267</span></a><span class="sd">                starts with double underscores.</span>
-</span><span id="RegisterReference-268"><a href="#RegisterReference-268"><span class="linenos">268</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="RegisterReference-269"><a href="#RegisterReference-269"><span class="linenos">269</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
-</span><span id="RegisterReference-270"><a href="#RegisterReference-270"><span class="linenos">270</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
-</span><span id="RegisterReference-271"><a href="#RegisterReference-271"><span class="linenos">271</span></a>
-</span><span id="RegisterReference-272"><a href="#RegisterReference-272"><span class="linenos">272</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="RegisterReference-273"><a href="#RegisterReference-273"><span class="linenos">273</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
-</span><span id="RegisterReference-274"><a href="#RegisterReference-274"><span class="linenos">274</span></a>
-</span><span id="RegisterReference-275"><a href="#RegisterReference-275"><span class="linenos">275</span></a><span class="sd">        Args:</span>
-</span><span id="RegisterReference-276"><a href="#RegisterReference-276"><span class="linenos">276</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
-</span><span id="RegisterReference-277"><a href="#RegisterReference-277"><span class="linenos">277</span></a>
-</span><span id="RegisterReference-278"><a href="#RegisterReference-278"><span class="linenos">278</span></a><span class="sd">        Returns:</span>
-</span><span id="RegisterReference-279"><a href="#RegisterReference-279"><span class="linenos">279</span></a><span class="sd">            The value currently stored in the referenced register.</span>
-</span><span id="RegisterReference-280"><a href="#RegisterReference-280"><span class="linenos">280</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="RegisterReference-281"><a href="#RegisterReference-281"><span class="linenos">281</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
-</span><span id="RegisterReference-282"><a href="#RegisterReference-282"><span class="linenos">282</span></a>
-</span><span id="RegisterReference-283"><a href="#RegisterReference-283"><span class="linenos">283</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="RegisterReference-284"><a href="#RegisterReference-284"><span class="linenos">284</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="RegisterReference-285"><a href="#RegisterReference-285"><span class="linenos">285</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference-257"><a href="#RegisterReference-257"><span class="linenos">257</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RegisterReference</span><span class="p">(</span><span class="n">Operand</span><span class="p">):</span>
+</span><span id="RegisterReference-258"><a href="#RegisterReference-258"><span class="linenos">258</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;An operand representing a CPU register reference.</span>
+</span><span id="RegisterReference-259"><a href="#RegisterReference-259"><span class="linenos">259</span></a>
+</span><span id="RegisterReference-260"><a href="#RegisterReference-260"><span class="linenos">260</span></a><span class="sd">    Register references resolve to the value stored in the named register.</span>
+</span><span id="RegisterReference-261"><a href="#RegisterReference-261"><span class="linenos">261</span></a>
+</span><span id="RegisterReference-262"><a href="#RegisterReference-262"><span class="linenos">262</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
+</span><span id="RegisterReference-263"><a href="#RegisterReference-263"><span class="linenos">263</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
+</span><span id="RegisterReference-264"><a href="#RegisterReference-264"><span class="linenos">264</span></a><span class="sd">    for dunder methods).</span>
+</span><span id="RegisterReference-265"><a href="#RegisterReference-265"><span class="linenos">265</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="RegisterReference-266"><a href="#RegisterReference-266"><span class="linenos">266</span></a>
+</span><span id="RegisterReference-267"><a href="#RegisterReference-267"><span class="linenos">267</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="RegisterReference-268"><a href="#RegisterReference-268"><span class="linenos">268</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
+</span><span id="RegisterReference-269"><a href="#RegisterReference-269"><span class="linenos">269</span></a>
+</span><span id="RegisterReference-270"><a href="#RegisterReference-270"><span class="linenos">270</span></a><span class="sd">        Args:</span>
+</span><span id="RegisterReference-271"><a href="#RegisterReference-271"><span class="linenos">271</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
+</span><span id="RegisterReference-272"><a href="#RegisterReference-272"><span class="linenos">272</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
+</span><span id="RegisterReference-273"><a href="#RegisterReference-273"><span class="linenos">273</span></a>
+</span><span id="RegisterReference-274"><a href="#RegisterReference-274"><span class="linenos">274</span></a><span class="sd">        Raises:</span>
+</span><span id="RegisterReference-275"><a href="#RegisterReference-275"><span class="linenos">275</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
+</span><span id="RegisterReference-276"><a href="#RegisterReference-276"><span class="linenos">276</span></a><span class="sd">                starts with double underscores.</span>
+</span><span id="RegisterReference-277"><a href="#RegisterReference-277"><span class="linenos">277</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RegisterReference-278"><a href="#RegisterReference-278"><span class="linenos">278</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
+</span><span id="RegisterReference-279"><a href="#RegisterReference-279"><span class="linenos">279</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
+</span><span id="RegisterReference-280"><a href="#RegisterReference-280"><span class="linenos">280</span></a>
+</span><span id="RegisterReference-281"><a href="#RegisterReference-281"><span class="linenos">281</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="RegisterReference-282"><a href="#RegisterReference-282"><span class="linenos">282</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
+</span><span id="RegisterReference-283"><a href="#RegisterReference-283"><span class="linenos">283</span></a>
+</span><span id="RegisterReference-284"><a href="#RegisterReference-284"><span class="linenos">284</span></a><span class="sd">        Args:</span>
+</span><span id="RegisterReference-285"><a href="#RegisterReference-285"><span class="linenos">285</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
 </span><span id="RegisterReference-286"><a href="#RegisterReference-286"><span class="linenos">286</span></a>
-</span><span id="RegisterReference-287"><a href="#RegisterReference-287"><span class="linenos">287</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="RegisterReference-288"><a href="#RegisterReference-288"><span class="linenos">288</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
-</span><span id="RegisterReference-289"><a href="#RegisterReference-289"><span class="linenos">289</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="RegisterReference-287"><a href="#RegisterReference-287"><span class="linenos">287</span></a><span class="sd">        Returns:</span>
+</span><span id="RegisterReference-288"><a href="#RegisterReference-288"><span class="linenos">288</span></a><span class="sd">            The value currently stored in the referenced register.</span>
+</span><span id="RegisterReference-289"><a href="#RegisterReference-289"><span class="linenos">289</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RegisterReference-290"><a href="#RegisterReference-290"><span class="linenos">290</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
+</span><span id="RegisterReference-291"><a href="#RegisterReference-291"><span class="linenos">291</span></a>
+</span><span id="RegisterReference-292"><a href="#RegisterReference-292"><span class="linenos">292</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="RegisterReference-293"><a href="#RegisterReference-293"><span class="linenos">293</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="RegisterReference-294"><a href="#RegisterReference-294"><span class="linenos">294</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="RegisterReference-295"><a href="#RegisterReference-295"><span class="linenos">295</span></a>
+</span><span id="RegisterReference-296"><a href="#RegisterReference-296"><span class="linenos">296</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="RegisterReference-297"><a href="#RegisterReference-297"><span class="linenos">297</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation.&quot;&quot;&quot;</span>
+</span><span id="RegisterReference-298"><a href="#RegisterReference-298"><span class="linenos">298</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;R.</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="si">}</span><span class="s2">&quot;</span>
 </span></pre></div>
 
 
@@ -1384,19 +1402,19 @@ for dunder methods).</p>
 
     </div>
     <a class="headerlink" href="#RegisterReference.__init__"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference.__init__-258"><a href="#RegisterReference.__init__-258"><span class="linenos">258</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="RegisterReference.__init__-259"><a href="#RegisterReference.__init__-259"><span class="linenos">259</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
-</span><span id="RegisterReference.__init__-260"><a href="#RegisterReference.__init__-260"><span class="linenos">260</span></a>
-</span><span id="RegisterReference.__init__-261"><a href="#RegisterReference.__init__-261"><span class="linenos">261</span></a><span class="sd">        Args:</span>
-</span><span id="RegisterReference.__init__-262"><a href="#RegisterReference.__init__-262"><span class="linenos">262</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
-</span><span id="RegisterReference.__init__-263"><a href="#RegisterReference.__init__-263"><span class="linenos">263</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
-</span><span id="RegisterReference.__init__-264"><a href="#RegisterReference.__init__-264"><span class="linenos">264</span></a>
-</span><span id="RegisterReference.__init__-265"><a href="#RegisterReference.__init__-265"><span class="linenos">265</span></a><span class="sd">        Raises:</span>
-</span><span id="RegisterReference.__init__-266"><a href="#RegisterReference.__init__-266"><span class="linenos">266</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
-</span><span id="RegisterReference.__init__-267"><a href="#RegisterReference.__init__-267"><span class="linenos">267</span></a><span class="sd">                starts with double underscores.</span>
-</span><span id="RegisterReference.__init__-268"><a href="#RegisterReference.__init__-268"><span class="linenos">268</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="RegisterReference.__init__-269"><a href="#RegisterReference.__init__-269"><span class="linenos">269</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
-</span><span id="RegisterReference.__init__-270"><a href="#RegisterReference.__init__-270"><span class="linenos">270</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference.__init__-267"><a href="#RegisterReference.__init__-267"><span class="linenos">267</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">register</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="RegisterReference.__init__-268"><a href="#RegisterReference.__init__-268"><span class="linenos">268</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a register reference operand.</span>
+</span><span id="RegisterReference.__init__-269"><a href="#RegisterReference.__init__-269"><span class="linenos">269</span></a>
+</span><span id="RegisterReference.__init__-270"><a href="#RegisterReference.__init__-270"><span class="linenos">270</span></a><span class="sd">        Args:</span>
+</span><span id="RegisterReference.__init__-271"><a href="#RegisterReference.__init__-271"><span class="linenos">271</span></a><span class="sd">            register: The name of the register to reference. Must be a valid Python</span>
+</span><span id="RegisterReference.__init__-272"><a href="#RegisterReference.__init__-272"><span class="linenos">272</span></a><span class="sd">                identifier and cannot start with double underscores.</span>
+</span><span id="RegisterReference.__init__-273"><a href="#RegisterReference.__init__-273"><span class="linenos">273</span></a>
+</span><span id="RegisterReference.__init__-274"><a href="#RegisterReference.__init__-274"><span class="linenos">274</span></a><span class="sd">        Raises:</span>
+</span><span id="RegisterReference.__init__-275"><a href="#RegisterReference.__init__-275"><span class="linenos">275</span></a><span class="sd">            ValueError: If the register name is not a valid Python identifier or</span>
+</span><span id="RegisterReference.__init__-276"><a href="#RegisterReference.__init__-276"><span class="linenos">276</span></a><span class="sd">                starts with double underscores.</span>
+</span><span id="RegisterReference.__init__-277"><a href="#RegisterReference.__init__-277"><span class="linenos">277</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RegisterReference.__init__-278"><a href="#RegisterReference.__init__-278"><span class="linenos">278</span></a>        <span class="n">validate_register_name</span><span class="p">(</span><span class="n">register</span><span class="p">)</span>
+</span><span id="RegisterReference.__init__-279"><a href="#RegisterReference.__init__-279"><span class="linenos">279</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">register</span> <span class="o">=</span> <span class="n">register</span>
 </span></pre></div>
 
 
@@ -1441,16 +1459,16 @@ starts with double underscores.</li>
 
     </div>
     <a class="headerlink" href="#RegisterReference.resolve"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference.resolve-272"><a href="#RegisterReference.resolve-272"><span class="linenos">272</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="RegisterReference.resolve-273"><a href="#RegisterReference.resolve-273"><span class="linenos">273</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
-</span><span id="RegisterReference.resolve-274"><a href="#RegisterReference.resolve-274"><span class="linenos">274</span></a>
-</span><span id="RegisterReference.resolve-275"><a href="#RegisterReference.resolve-275"><span class="linenos">275</span></a><span class="sd">        Args:</span>
-</span><span id="RegisterReference.resolve-276"><a href="#RegisterReference.resolve-276"><span class="linenos">276</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
-</span><span id="RegisterReference.resolve-277"><a href="#RegisterReference.resolve-277"><span class="linenos">277</span></a>
-</span><span id="RegisterReference.resolve-278"><a href="#RegisterReference.resolve-278"><span class="linenos">278</span></a><span class="sd">        Returns:</span>
-</span><span id="RegisterReference.resolve-279"><a href="#RegisterReference.resolve-279"><span class="linenos">279</span></a><span class="sd">            The value currently stored in the referenced register.</span>
-</span><span id="RegisterReference.resolve-280"><a href="#RegisterReference.resolve-280"><span class="linenos">280</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="RegisterReference.resolve-281"><a href="#RegisterReference.resolve-281"><span class="linenos">281</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RegisterReference.resolve-281"><a href="#RegisterReference.resolve-281"><span class="linenos">281</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="RegisterReference.resolve-282"><a href="#RegisterReference.resolve-282"><span class="linenos">282</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the register reference to its current value.</span>
+</span><span id="RegisterReference.resolve-283"><a href="#RegisterReference.resolve-283"><span class="linenos">283</span></a>
+</span><span id="RegisterReference.resolve-284"><a href="#RegisterReference.resolve-284"><span class="linenos">284</span></a><span class="sd">        Args:</span>
+</span><span id="RegisterReference.resolve-285"><a href="#RegisterReference.resolve-285"><span class="linenos">285</span></a><span class="sd">            cpu: The DT31 CPU instance providing register access.</span>
+</span><span id="RegisterReference.resolve-286"><a href="#RegisterReference.resolve-286"><span class="linenos">286</span></a>
+</span><span id="RegisterReference.resolve-287"><a href="#RegisterReference.resolve-287"><span class="linenos">287</span></a><span class="sd">        Returns:</span>
+</span><span id="RegisterReference.resolve-288"><a href="#RegisterReference.resolve-288"><span class="linenos">288</span></a><span class="sd">            The value currently stored in the referenced register.</span>
+</span><span id="RegisterReference.resolve-289"><a href="#RegisterReference.resolve-289"><span class="linenos">289</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RegisterReference.resolve-290"><a href="#RegisterReference.resolve-290"><span class="linenos">290</span></a>        <span class="k">return</span> <span class="n">cpu</span><span class="o">.</span><span class="n">get_register</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">register</span><span class="p">)</span>
 </span></pre></div>
 
 
@@ -1483,25 +1501,25 @@ starts with double underscores.</li>
 
     </div>
     <a class="headerlink" href="#R"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="R-313"><a href="#R-313"><span class="linenos">313</span></a><span class="k">class</span><span class="w"> </span><span class="nc">R</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaRegister</span><span class="p">):</span>
-</span><span id="R-314"><a href="#R-314"><span class="linenos">314</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating RegisterReference operands.</span>
-</span><span id="R-315"><a href="#R-315"><span class="linenos">315</span></a>
-</span><span id="R-316"><a href="#R-316"><span class="linenos">316</span></a><span class="sd">    Uses attribute syntax for ergonomic register references.</span>
-</span><span id="R-317"><a href="#R-317"><span class="linenos">317</span></a>
-</span><span id="R-318"><a href="#R-318"><span class="linenos">318</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
-</span><span id="R-319"><a href="#R-319"><span class="linenos">319</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
-</span><span id="R-320"><a href="#R-320"><span class="linenos">320</span></a><span class="sd">    for dunder methods).</span>
-</span><span id="R-321"><a href="#R-321"><span class="linenos">321</span></a>
-</span><span id="R-322"><a href="#R-322"><span class="linenos">322</span></a><span class="sd">    Examples:</span>
-</span><span id="R-323"><a href="#R-323"><span class="linenos">323</span></a><span class="sd">        R.a         # Creates RegisterReference(&quot;a&quot;)</span>
-</span><span id="R-324"><a href="#R-324"><span class="linenos">324</span></a><span class="sd">        R.foo       # Creates RegisterReference(&quot;foo&quot;)</span>
-</span><span id="R-325"><a href="#R-325"><span class="linenos">325</span></a><span class="sd">        R.my_reg    # Creates RegisterReference(&quot;my_reg&quot;)</span>
-</span><span id="R-326"><a href="#R-326"><span class="linenos">326</span></a><span class="sd">        R._temp     # Creates RegisterReference(&quot;_temp&quot;) - valid</span>
-</span><span id="R-327"><a href="#R-327"><span class="linenos">327</span></a><span class="sd">        R.__dunder  # Raises ValueError - double underscore prefix not allowed</span>
-</span><span id="R-328"><a href="#R-328"><span class="linenos">328</span></a><span class="sd">        R.123       # SyntaxError - identifiers cannot start with digits</span>
-</span><span id="R-329"><a href="#R-329"><span class="linenos">329</span></a><span class="sd">    &quot;&quot;&quot;</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="R-322"><a href="#R-322"><span class="linenos">322</span></a><span class="k">class</span><span class="w"> </span><span class="nc">R</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">_MetaRegister</span><span class="p">):</span>
+</span><span id="R-323"><a href="#R-323"><span class="linenos">323</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Convenience class for creating RegisterReference operands.</span>
+</span><span id="R-324"><a href="#R-324"><span class="linenos">324</span></a>
+</span><span id="R-325"><a href="#R-325"><span class="linenos">325</span></a><span class="sd">    Uses attribute syntax for ergonomic register references.</span>
+</span><span id="R-326"><a href="#R-326"><span class="linenos">326</span></a>
+</span><span id="R-327"><a href="#R-327"><span class="linenos">327</span></a><span class="sd">    Register names must be valid Python identifiers (letters, digits, underscores;</span>
+</span><span id="R-328"><a href="#R-328"><span class="linenos">328</span></a><span class="sd">    cannot start with a digit) and cannot start with double underscores (reserved</span>
+</span><span id="R-329"><a href="#R-329"><span class="linenos">329</span></a><span class="sd">    for dunder methods).</span>
 </span><span id="R-330"><a href="#R-330"><span class="linenos">330</span></a>
-</span><span id="R-331"><a href="#R-331"><span class="linenos">331</span></a>    <span class="k">pass</span>
+</span><span id="R-331"><a href="#R-331"><span class="linenos">331</span></a><span class="sd">    Examples:</span>
+</span><span id="R-332"><a href="#R-332"><span class="linenos">332</span></a><span class="sd">        R.a         # Creates RegisterReference(&quot;a&quot;)</span>
+</span><span id="R-333"><a href="#R-333"><span class="linenos">333</span></a><span class="sd">        R.foo       # Creates RegisterReference(&quot;foo&quot;)</span>
+</span><span id="R-334"><a href="#R-334"><span class="linenos">334</span></a><span class="sd">        R.my_reg    # Creates RegisterReference(&quot;my_reg&quot;)</span>
+</span><span id="R-335"><a href="#R-335"><span class="linenos">335</span></a><span class="sd">        R._temp     # Creates RegisterReference(&quot;_temp&quot;) - valid</span>
+</span><span id="R-336"><a href="#R-336"><span class="linenos">336</span></a><span class="sd">        R.__dunder  # Raises ValueError - double underscore prefix not allowed</span>
+</span><span id="R-337"><a href="#R-337"><span class="linenos">337</span></a><span class="sd">        R.123       # SyntaxError - identifiers cannot start with digits</span>
+</span><span id="R-338"><a href="#R-338"><span class="linenos">338</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="R-339"><a href="#R-339"><span class="linenos">339</span></a>
+</span><span id="R-340"><a href="#R-340"><span class="linenos">340</span></a>    <span class="k">pass</span>
 </span></pre></div>
 
 
@@ -1550,26 +1568,26 @@ for dunder methods).</p>
 
     </div>
     <a class="headerlink" href="#as_op"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="as_op-337"><a href="#as_op-337"><span class="linenos">337</span></a><span class="k">def</span><span class="w"> </span><span class="nf">as_op</span><span class="p">(</span><span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="as_op-338"><a href="#as_op-338"><span class="linenos">338</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Coerce a value into an Operand.</span>
-</span><span id="as_op-339"><a href="#as_op-339"><span class="linenos">339</span></a>
-</span><span id="as_op-340"><a href="#as_op-340"><span class="linenos">340</span></a><span class="sd">    Converts integers to Literal operands, while passing through existing operands.</span>
-</span><span id="as_op-341"><a href="#as_op-341"><span class="linenos">341</span></a>
-</span><span id="as_op-342"><a href="#as_op-342"><span class="linenos">342</span></a><span class="sd">    Args:</span>
-</span><span id="as_op-343"><a href="#as_op-343"><span class="linenos">343</span></a><span class="sd">        arg: Either an integer to be converted or an existing Operand.</span>
-</span><span id="as_op-344"><a href="#as_op-344"><span class="linenos">344</span></a>
-</span><span id="as_op-345"><a href="#as_op-345"><span class="linenos">345</span></a><span class="sd">    Returns:</span>
-</span><span id="as_op-346"><a href="#as_op-346"><span class="linenos">346</span></a><span class="sd">        An Operand instance (either the input operand or a new Literal).</span>
-</span><span id="as_op-347"><a href="#as_op-347"><span class="linenos">347</span></a>
-</span><span id="as_op-348"><a href="#as_op-348"><span class="linenos">348</span></a><span class="sd">    Raises:</span>
-</span><span id="as_op-349"><a href="#as_op-349"><span class="linenos">349</span></a><span class="sd">        ValueError: If the argument cannot be coerced into an operand.</span>
-</span><span id="as_op-350"><a href="#as_op-350"><span class="linenos">350</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="as_op-351"><a href="#as_op-351"><span class="linenos">351</span></a>    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="n">Operand</span><span class="p">):</span>
-</span><span id="as_op-352"><a href="#as_op-352"><span class="linenos">352</span></a>        <span class="k">return</span> <span class="n">arg</span>
-</span><span id="as_op-353"><a href="#as_op-353"><span class="linenos">353</span></a>    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
-</span><span id="as_op-354"><a href="#as_op-354"><span class="linenos">354</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
-</span><span id="as_op-355"><a href="#as_op-355"><span class="linenos">355</span></a>    <span class="k">else</span><span class="p">:</span>
-</span><span id="as_op-356"><a href="#as_op-356"><span class="linenos">356</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;can&#39;t coerce value </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2"> into operand&quot;</span><span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="as_op-346"><a href="#as_op-346"><span class="linenos">346</span></a><span class="k">def</span><span class="w"> </span><span class="nf">as_op</span><span class="p">(</span><span class="n">arg</span><span class="p">:</span> <span class="nb">int</span> <span class="o">|</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="as_op-347"><a href="#as_op-347"><span class="linenos">347</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Coerce a value into an Operand.</span>
+</span><span id="as_op-348"><a href="#as_op-348"><span class="linenos">348</span></a>
+</span><span id="as_op-349"><a href="#as_op-349"><span class="linenos">349</span></a><span class="sd">    Converts integers to Literal operands, while passing through existing operands.</span>
+</span><span id="as_op-350"><a href="#as_op-350"><span class="linenos">350</span></a>
+</span><span id="as_op-351"><a href="#as_op-351"><span class="linenos">351</span></a><span class="sd">    Args:</span>
+</span><span id="as_op-352"><a href="#as_op-352"><span class="linenos">352</span></a><span class="sd">        arg: Either an integer to be converted or an existing Operand.</span>
+</span><span id="as_op-353"><a href="#as_op-353"><span class="linenos">353</span></a>
+</span><span id="as_op-354"><a href="#as_op-354"><span class="linenos">354</span></a><span class="sd">    Returns:</span>
+</span><span id="as_op-355"><a href="#as_op-355"><span class="linenos">355</span></a><span class="sd">        An Operand instance (either the input operand or a new Literal).</span>
+</span><span id="as_op-356"><a href="#as_op-356"><span class="linenos">356</span></a>
+</span><span id="as_op-357"><a href="#as_op-357"><span class="linenos">357</span></a><span class="sd">    Raises:</span>
+</span><span id="as_op-358"><a href="#as_op-358"><span class="linenos">358</span></a><span class="sd">        ValueError: If the argument cannot be coerced into an operand.</span>
+</span><span id="as_op-359"><a href="#as_op-359"><span class="linenos">359</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="as_op-360"><a href="#as_op-360"><span class="linenos">360</span></a>    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="n">Operand</span><span class="p">):</span>
+</span><span id="as_op-361"><a href="#as_op-361"><span class="linenos">361</span></a>        <span class="k">return</span> <span class="n">arg</span>
+</span><span id="as_op-362"><a href="#as_op-362"><span class="linenos">362</span></a>    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">arg</span><span class="p">,</span> <span class="nb">int</span><span class="p">):</span>
+</span><span id="as_op-363"><a href="#as_op-363"><span class="linenos">363</span></a>        <span class="k">return</span> <span class="n">Literal</span><span class="p">(</span><span class="n">arg</span><span class="p">)</span>
+</span><span id="as_op-364"><a href="#as_op-364"><span class="linenos">364</span></a>    <span class="k">else</span><span class="p">:</span>
+</span><span id="as_op-365"><a href="#as_op-365"><span class="linenos">365</span></a>        <span class="k">raise</span> <span class="ne">ValueError</span><span class="p">(</span><span class="sa">f</span><span class="s2">&quot;can&#39;t coerce value </span><span class="si">{</span><span class="n">arg</span><span class="si">}</span><span class="s2"> into operand&quot;</span><span class="p">)</span>
 </span></pre></div>
 
 
@@ -1609,140 +1627,140 @@ for dunder methods).</p>
 
     </div>
     <a class="headerlink" href="#Label"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="Label-359"><a href="#Label-359"><span class="linenos">359</span></a><span class="k">class</span><span class="w"> </span><span class="nc">Label</span><span class="p">:</span>
-</span><span id="Label-360"><a href="#Label-360"><span class="linenos">360</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A named label that marks a position in the program for jumps and calls.</span>
-</span><span id="Label-361"><a href="#Label-361"><span class="linenos">361</span></a>
-</span><span id="Label-362"><a href="#Label-362"><span class="linenos">362</span></a><span class="sd">    Labels are assembly-time constructs used to mark instruction positions in a program.</span>
-</span><span id="Label-363"><a href="#Label-363"><span class="linenos">363</span></a><span class="sd">    They are removed during the assembly process and replaced with numeric instruction</span>
-</span><span id="Label-364"><a href="#Label-364"><span class="linenos">364</span></a><span class="sd">    indices. Labels can only be used as destinations for jump and call instructions.</span>
-</span><span id="Label-365"><a href="#Label-365"><span class="linenos">365</span></a>
-</span><span id="Label-366"><a href="#Label-366"><span class="linenos">366</span></a><span class="sd">    Usage</span>
-</span><span id="Label-367"><a href="#Label-367"><span class="linenos">367</span></a><span class="sd">    -----</span>
-</span><span id="Label-368"><a href="#Label-368"><span class="linenos">368</span></a><span class="sd">    Labels are used in two contexts:</span>
-</span><span id="Label-369"><a href="#Label-369"><span class="linenos">369</span></a>
-</span><span id="Label-370"><a href="#Label-370"><span class="linenos">370</span></a><span class="sd">    1. **Definition**: Place a Label directly in the program list to mark a position:</span>
-</span><span id="Label-371"><a href="#Label-371"><span class="linenos">371</span></a><span class="sd">       ```python</span>
-</span><span id="Label-372"><a href="#Label-372"><span class="linenos">372</span></a><span class="sd">       program = [</span>
-</span><span id="Label-373"><a href="#Label-373"><span class="linenos">373</span></a><span class="sd">           I.CP(R.a, L[0]),</span>
-</span><span id="Label-374"><a href="#Label-374"><span class="linenos">374</span></a><span class="sd">           Label(&quot;loop&quot;),      # Marks this position</span>
-</span><span id="Label-375"><a href="#Label-375"><span class="linenos">375</span></a><span class="sd">           I.ADD(R.a, L[1]),</span>
-</span><span id="Label-376"><a href="#Label-376"><span class="linenos">376</span></a><span class="sd">       ]</span>
-</span><span id="Label-377"><a href="#Label-377"><span class="linenos">377</span></a><span class="sd">       ```</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Label-368"><a href="#Label-368"><span class="linenos">368</span></a><span class="k">class</span><span class="w"> </span><span class="nc">Label</span><span class="p">:</span>
+</span><span id="Label-369"><a href="#Label-369"><span class="linenos">369</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;A named label that marks a position in the program for jumps and calls.</span>
+</span><span id="Label-370"><a href="#Label-370"><span class="linenos">370</span></a>
+</span><span id="Label-371"><a href="#Label-371"><span class="linenos">371</span></a><span class="sd">    Labels are assembly-time constructs used to mark instruction positions in a program.</span>
+</span><span id="Label-372"><a href="#Label-372"><span class="linenos">372</span></a><span class="sd">    They are removed during the assembly process and replaced with numeric instruction</span>
+</span><span id="Label-373"><a href="#Label-373"><span class="linenos">373</span></a><span class="sd">    indices. Labels can only be used as destinations for jump and call instructions.</span>
+</span><span id="Label-374"><a href="#Label-374"><span class="linenos">374</span></a>
+</span><span id="Label-375"><a href="#Label-375"><span class="linenos">375</span></a><span class="sd">    Usage</span>
+</span><span id="Label-376"><a href="#Label-376"><span class="linenos">376</span></a><span class="sd">    -----</span>
+</span><span id="Label-377"><a href="#Label-377"><span class="linenos">377</span></a><span class="sd">    Labels are used in two contexts:</span>
 </span><span id="Label-378"><a href="#Label-378"><span class="linenos">378</span></a>
-</span><span id="Label-379"><a href="#Label-379"><span class="linenos">379</span></a><span class="sd">    2. **Reference**: Use a Label as the destination operand in jump/call instructions:</span>
+</span><span id="Label-379"><a href="#Label-379"><span class="linenos">379</span></a><span class="sd">    1. **Definition**: Place a Label directly in the program list to mark a position:</span>
 </span><span id="Label-380"><a href="#Label-380"><span class="linenos">380</span></a><span class="sd">       ```python</span>
-</span><span id="Label-381"><a href="#Label-381"><span class="linenos">381</span></a><span class="sd">       I.JMP(Label(&quot;loop&quot;))     # Jump to the position marked by &quot;loop&quot;</span>
-</span><span id="Label-382"><a href="#Label-382"><span class="linenos">382</span></a><span class="sd">       I.CALL(Label(&quot;func&quot;))    # Call the function at &quot;func&quot;</span>
-</span><span id="Label-383"><a href="#Label-383"><span class="linenos">383</span></a><span class="sd">       I.RJGT(Label(&quot;start&quot;), R.a, L[10])  # Conditional relative jump</span>
-</span><span id="Label-384"><a href="#Label-384"><span class="linenos">384</span></a><span class="sd">       ```</span>
-</span><span id="Label-385"><a href="#Label-385"><span class="linenos">385</span></a>
-</span><span id="Label-386"><a href="#Label-386"><span class="linenos">386</span></a><span class="sd">    Valid Instructions for Labels</span>
-</span><span id="Label-387"><a href="#Label-387"><span class="linenos">387</span></a><span class="sd">    ------------------------------</span>
-</span><span id="Label-388"><a href="#Label-388"><span class="linenos">388</span></a><span class="sd">    Labels can ONLY be used as the `dest` argument in these instructions:</span>
-</span><span id="Label-389"><a href="#Label-389"><span class="linenos">389</span></a><span class="sd">    - Absolute jumps: JMP, JEQ, JNE, JGT, JGE, JIF</span>
-</span><span id="Label-390"><a href="#Label-390"><span class="linenos">390</span></a><span class="sd">    - Relative jumps: RJMP, RJEQ, RJNE, RJGT, RJGE, RJIF</span>
-</span><span id="Label-391"><a href="#Label-391"><span class="linenos">391</span></a><span class="sd">    - Function calls: CALL, RCALL</span>
-</span><span id="Label-392"><a href="#Label-392"><span class="linenos">392</span></a>
-</span><span id="Label-393"><a href="#Label-393"><span class="linenos">393</span></a><span class="sd">    Invalid Usage</span>
-</span><span id="Label-394"><a href="#Label-394"><span class="linenos">394</span></a><span class="sd">    -------------</span>
-</span><span id="Label-395"><a href="#Label-395"><span class="linenos">395</span></a><span class="sd">    Labels cannot be used in arithmetic, logic, or other operations:</span>
-</span><span id="Label-396"><a href="#Label-396"><span class="linenos">396</span></a><span class="sd">    ```python</span>
-</span><span id="Label-397"><a href="#Label-397"><span class="linenos">397</span></a><span class="sd">    I.ADD(R.a, Label(&quot;x&quot;))      # INVALID - will cause runtime error</span>
-</span><span id="Label-398"><a href="#Label-398"><span class="linenos">398</span></a><span class="sd">    I.CP(Label(&quot;foo&quot;), R.b)     # INVALID - will cause runtime error</span>
-</span><span id="Label-399"><a href="#Label-399"><span class="linenos">399</span></a><span class="sd">    M[Label(&quot;addr&quot;)]            # INVALID - will cause runtime error</span>
-</span><span id="Label-400"><a href="#Label-400"><span class="linenos">400</span></a><span class="sd">    ```</span>
+</span><span id="Label-381"><a href="#Label-381"><span class="linenos">381</span></a><span class="sd">       program = [</span>
+</span><span id="Label-382"><a href="#Label-382"><span class="linenos">382</span></a><span class="sd">           I.CP(R.a, L[0]),</span>
+</span><span id="Label-383"><a href="#Label-383"><span class="linenos">383</span></a><span class="sd">           Label(&quot;loop&quot;),      # Marks this position</span>
+</span><span id="Label-384"><a href="#Label-384"><span class="linenos">384</span></a><span class="sd">           I.ADD(R.a, L[1]),</span>
+</span><span id="Label-385"><a href="#Label-385"><span class="linenos">385</span></a><span class="sd">       ]</span>
+</span><span id="Label-386"><a href="#Label-386"><span class="linenos">386</span></a><span class="sd">       ```</span>
+</span><span id="Label-387"><a href="#Label-387"><span class="linenos">387</span></a>
+</span><span id="Label-388"><a href="#Label-388"><span class="linenos">388</span></a><span class="sd">    2. **Reference**: Use a Label as the destination operand in jump/call instructions:</span>
+</span><span id="Label-389"><a href="#Label-389"><span class="linenos">389</span></a><span class="sd">       ```python</span>
+</span><span id="Label-390"><a href="#Label-390"><span class="linenos">390</span></a><span class="sd">       I.JMP(Label(&quot;loop&quot;))     # Jump to the position marked by &quot;loop&quot;</span>
+</span><span id="Label-391"><a href="#Label-391"><span class="linenos">391</span></a><span class="sd">       I.CALL(Label(&quot;func&quot;))    # Call the function at &quot;func&quot;</span>
+</span><span id="Label-392"><a href="#Label-392"><span class="linenos">392</span></a><span class="sd">       I.RJGT(Label(&quot;start&quot;), R.a, L[10])  # Conditional relative jump</span>
+</span><span id="Label-393"><a href="#Label-393"><span class="linenos">393</span></a><span class="sd">       ```</span>
+</span><span id="Label-394"><a href="#Label-394"><span class="linenos">394</span></a>
+</span><span id="Label-395"><a href="#Label-395"><span class="linenos">395</span></a><span class="sd">    Valid Instructions for Labels</span>
+</span><span id="Label-396"><a href="#Label-396"><span class="linenos">396</span></a><span class="sd">    ------------------------------</span>
+</span><span id="Label-397"><a href="#Label-397"><span class="linenos">397</span></a><span class="sd">    Labels can ONLY be used as the `dest` argument in these instructions:</span>
+</span><span id="Label-398"><a href="#Label-398"><span class="linenos">398</span></a><span class="sd">    - Absolute jumps: JMP, JEQ, JNE, JGT, JGE, JIF</span>
+</span><span id="Label-399"><a href="#Label-399"><span class="linenos">399</span></a><span class="sd">    - Relative jumps: RJMP, RJEQ, RJNE, RJGT, RJGE, RJIF</span>
+</span><span id="Label-400"><a href="#Label-400"><span class="linenos">400</span></a><span class="sd">    - Function calls: CALL, RCALL</span>
 </span><span id="Label-401"><a href="#Label-401"><span class="linenos">401</span></a>
-</span><span id="Label-402"><a href="#Label-402"><span class="linenos">402</span></a><span class="sd">    Examples</span>
-</span><span id="Label-403"><a href="#Label-403"><span class="linenos">403</span></a><span class="sd">    --------</span>
-</span><span id="Label-404"><a href="#Label-404"><span class="linenos">404</span></a><span class="sd">    Simple loop counting from 0 to 10:</span>
+</span><span id="Label-402"><a href="#Label-402"><span class="linenos">402</span></a><span class="sd">    Invalid Usage</span>
+</span><span id="Label-403"><a href="#Label-403"><span class="linenos">403</span></a><span class="sd">    -------------</span>
+</span><span id="Label-404"><a href="#Label-404"><span class="linenos">404</span></a><span class="sd">    Labels cannot be used in arithmetic, logic, or other operations:</span>
 </span><span id="Label-405"><a href="#Label-405"><span class="linenos">405</span></a><span class="sd">    ```python</span>
-</span><span id="Label-406"><a href="#Label-406"><span class="linenos">406</span></a><span class="sd">    from dt31 import DT31, I, R, L, Label</span>
-</span><span id="Label-407"><a href="#Label-407"><span class="linenos">407</span></a><span class="sd">    from dt31.assembler import assemble</span>
-</span><span id="Label-408"><a href="#Label-408"><span class="linenos">408</span></a>
-</span><span id="Label-409"><a href="#Label-409"><span class="linenos">409</span></a><span class="sd">    loop = Label(&quot;loop&quot;)</span>
-</span><span id="Label-410"><a href="#Label-410"><span class="linenos">410</span></a><span class="sd">    program = [</span>
-</span><span id="Label-411"><a href="#Label-411"><span class="linenos">411</span></a><span class="sd">        I.CP(R.a, L[0]),</span>
-</span><span id="Label-412"><a href="#Label-412"><span class="linenos">412</span></a><span class="sd">        loop,                          # Mark loop start</span>
-</span><span id="Label-413"><a href="#Label-413"><span class="linenos">413</span></a><span class="sd">        I.NOUT(R.a, L[1]),             # Print counter</span>
-</span><span id="Label-414"><a href="#Label-414"><span class="linenos">414</span></a><span class="sd">        I.ADD(R.a, L[1]),              # Increment</span>
-</span><span id="Label-415"><a href="#Label-415"><span class="linenos">415</span></a><span class="sd">        I.JGT(loop, L[10], R.a),       # Continue if a &lt;= 10</span>
-</span><span id="Label-416"><a href="#Label-416"><span class="linenos">416</span></a><span class="sd">    ]</span>
+</span><span id="Label-406"><a href="#Label-406"><span class="linenos">406</span></a><span class="sd">    I.ADD(R.a, Label(&quot;x&quot;))      # INVALID - will cause runtime error</span>
+</span><span id="Label-407"><a href="#Label-407"><span class="linenos">407</span></a><span class="sd">    I.CP(Label(&quot;foo&quot;), R.b)     # INVALID - will cause runtime error</span>
+</span><span id="Label-408"><a href="#Label-408"><span class="linenos">408</span></a><span class="sd">    M[Label(&quot;addr&quot;)]            # INVALID - will cause runtime error</span>
+</span><span id="Label-409"><a href="#Label-409"><span class="linenos">409</span></a><span class="sd">    ```</span>
+</span><span id="Label-410"><a href="#Label-410"><span class="linenos">410</span></a>
+</span><span id="Label-411"><a href="#Label-411"><span class="linenos">411</span></a><span class="sd">    Examples</span>
+</span><span id="Label-412"><a href="#Label-412"><span class="linenos">412</span></a><span class="sd">    --------</span>
+</span><span id="Label-413"><a href="#Label-413"><span class="linenos">413</span></a><span class="sd">    Simple loop counting from 0 to 10:</span>
+</span><span id="Label-414"><a href="#Label-414"><span class="linenos">414</span></a><span class="sd">    ```python</span>
+</span><span id="Label-415"><a href="#Label-415"><span class="linenos">415</span></a><span class="sd">    from dt31 import DT31, I, R, L, Label</span>
+</span><span id="Label-416"><a href="#Label-416"><span class="linenos">416</span></a><span class="sd">    from dt31.assembler import assemble</span>
 </span><span id="Label-417"><a href="#Label-417"><span class="linenos">417</span></a>
-</span><span id="Label-418"><a href="#Label-418"><span class="linenos">418</span></a><span class="sd">    cpu = DT31()</span>
-</span><span id="Label-419"><a href="#Label-419"><span class="linenos">419</span></a><span class="sd">    cpu.run(assemble(program))</span>
-</span><span id="Label-420"><a href="#Label-420"><span class="linenos">420</span></a><span class="sd">    ```</span>
-</span><span id="Label-421"><a href="#Label-421"><span class="linenos">421</span></a>
-</span><span id="Label-422"><a href="#Label-422"><span class="linenos">422</span></a><span class="sd">    Function with label:</span>
-</span><span id="Label-423"><a href="#Label-423"><span class="linenos">423</span></a><span class="sd">    ```python</span>
-</span><span id="Label-424"><a href="#Label-424"><span class="linenos">424</span></a><span class="sd">    program = [</span>
-</span><span id="Label-425"><a href="#Label-425"><span class="linenos">425</span></a><span class="sd">        I.CALL(Label(&quot;greet&quot;)),</span>
-</span><span id="Label-426"><a href="#Label-426"><span class="linenos">426</span></a><span class="sd">        I.JMP(Label(&quot;end&quot;)),</span>
-</span><span id="Label-427"><a href="#Label-427"><span class="linenos">427</span></a>
-</span><span id="Label-428"><a href="#Label-428"><span class="linenos">428</span></a><span class="sd">        Label(&quot;greet&quot;),</span>
-</span><span id="Label-429"><a href="#Label-429"><span class="linenos">429</span></a><span class="sd">        I.COUT(LC[&#39;H&#39;]),</span>
-</span><span id="Label-430"><a href="#Label-430"><span class="linenos">430</span></a><span class="sd">        I.COUT(LC[&#39;i&#39;]),</span>
-</span><span id="Label-431"><a href="#Label-431"><span class="linenos">431</span></a><span class="sd">        I.RET(),</span>
-</span><span id="Label-432"><a href="#Label-432"><span class="linenos">432</span></a>
-</span><span id="Label-433"><a href="#Label-433"><span class="linenos">433</span></a><span class="sd">        Label(&quot;end&quot;),</span>
-</span><span id="Label-434"><a href="#Label-434"><span class="linenos">434</span></a><span class="sd">    ]</span>
-</span><span id="Label-435"><a href="#Label-435"><span class="linenos">435</span></a><span class="sd">    ```</span>
-</span><span id="Label-436"><a href="#Label-436"><span class="linenos">436</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="Label-437"><a href="#Label-437"><span class="linenos">437</span></a>
-</span><span id="Label-438"><a href="#Label-438"><span class="linenos">438</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Label-439"><a href="#Label-439"><span class="linenos">439</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
-</span><span id="Label-440"><a href="#Label-440"><span class="linenos">440</span></a>
-</span><span id="Label-441"><a href="#Label-441"><span class="linenos">441</span></a><span class="sd">        Args:</span>
-</span><span id="Label-442"><a href="#Label-442"><span class="linenos">442</span></a><span class="sd">            name: The symbolic name for this label.</span>
-</span><span id="Label-443"><a href="#Label-443"><span class="linenos">443</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label-444"><a href="#Label-444"><span class="linenos">444</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-</span><span id="Label-445"><a href="#Label-445"><span class="linenos">445</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
+</span><span id="Label-418"><a href="#Label-418"><span class="linenos">418</span></a><span class="sd">    loop = Label(&quot;loop&quot;)</span>
+</span><span id="Label-419"><a href="#Label-419"><span class="linenos">419</span></a><span class="sd">    program = [</span>
+</span><span id="Label-420"><a href="#Label-420"><span class="linenos">420</span></a><span class="sd">        I.CP(R.a, L[0]),</span>
+</span><span id="Label-421"><a href="#Label-421"><span class="linenos">421</span></a><span class="sd">        loop,                          # Mark loop start</span>
+</span><span id="Label-422"><a href="#Label-422"><span class="linenos">422</span></a><span class="sd">        I.NOUT(R.a, L[1]),             # Print counter</span>
+</span><span id="Label-423"><a href="#Label-423"><span class="linenos">423</span></a><span class="sd">        I.ADD(R.a, L[1]),              # Increment</span>
+</span><span id="Label-424"><a href="#Label-424"><span class="linenos">424</span></a><span class="sd">        I.JGT(loop, L[10], R.a),       # Continue if a &lt;= 10</span>
+</span><span id="Label-425"><a href="#Label-425"><span class="linenos">425</span></a><span class="sd">    ]</span>
+</span><span id="Label-426"><a href="#Label-426"><span class="linenos">426</span></a>
+</span><span id="Label-427"><a href="#Label-427"><span class="linenos">427</span></a><span class="sd">    cpu = DT31()</span>
+</span><span id="Label-428"><a href="#Label-428"><span class="linenos">428</span></a><span class="sd">    cpu.run(assemble(program))</span>
+</span><span id="Label-429"><a href="#Label-429"><span class="linenos">429</span></a><span class="sd">    ```</span>
+</span><span id="Label-430"><a href="#Label-430"><span class="linenos">430</span></a>
+</span><span id="Label-431"><a href="#Label-431"><span class="linenos">431</span></a><span class="sd">    Function with label:</span>
+</span><span id="Label-432"><a href="#Label-432"><span class="linenos">432</span></a><span class="sd">    ```python</span>
+</span><span id="Label-433"><a href="#Label-433"><span class="linenos">433</span></a><span class="sd">    program = [</span>
+</span><span id="Label-434"><a href="#Label-434"><span class="linenos">434</span></a><span class="sd">        I.CALL(Label(&quot;greet&quot;)),</span>
+</span><span id="Label-435"><a href="#Label-435"><span class="linenos">435</span></a><span class="sd">        I.JMP(Label(&quot;end&quot;)),</span>
+</span><span id="Label-436"><a href="#Label-436"><span class="linenos">436</span></a>
+</span><span id="Label-437"><a href="#Label-437"><span class="linenos">437</span></a><span class="sd">        Label(&quot;greet&quot;),</span>
+</span><span id="Label-438"><a href="#Label-438"><span class="linenos">438</span></a><span class="sd">        I.COUT(LC[&#39;H&#39;]),</span>
+</span><span id="Label-439"><a href="#Label-439"><span class="linenos">439</span></a><span class="sd">        I.COUT(LC[&#39;i&#39;]),</span>
+</span><span id="Label-440"><a href="#Label-440"><span class="linenos">440</span></a><span class="sd">        I.RET(),</span>
+</span><span id="Label-441"><a href="#Label-441"><span class="linenos">441</span></a>
+</span><span id="Label-442"><a href="#Label-442"><span class="linenos">442</span></a><span class="sd">        Label(&quot;end&quot;),</span>
+</span><span id="Label-443"><a href="#Label-443"><span class="linenos">443</span></a><span class="sd">    ]</span>
+</span><span id="Label-444"><a href="#Label-444"><span class="linenos">444</span></a><span class="sd">    ```</span>
+</span><span id="Label-445"><a href="#Label-445"><span class="linenos">445</span></a><span class="sd">    &quot;&quot;&quot;</span>
 </span><span id="Label-446"><a href="#Label-446"><span class="linenos">446</span></a>
-</span><span id="Label-447"><a href="#Label-447"><span class="linenos">447</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="Label-448"><a href="#Label-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
+</span><span id="Label-447"><a href="#Label-447"><span class="linenos">447</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="Label-448"><a href="#Label-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
 </span><span id="Label-449"><a href="#Label-449"><span class="linenos">449</span></a>
-</span><span id="Label-450"><a href="#Label-450"><span class="linenos">450</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
-</span><span id="Label-451"><a href="#Label-451"><span class="linenos">451</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
-</span><span id="Label-452"><a href="#Label-452"><span class="linenos">452</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
-</span><span id="Label-453"><a href="#Label-453"><span class="linenos">453</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
-</span><span id="Label-454"><a href="#Label-454"><span class="linenos">454</span></a>
-</span><span id="Label-455"><a href="#Label-455"><span class="linenos">455</span></a><span class="sd">        Args:</span>
-</span><span id="Label-456"><a href="#Label-456"><span class="linenos">456</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
-</span><span id="Label-457"><a href="#Label-457"><span class="linenos">457</span></a>
-</span><span id="Label-458"><a href="#Label-458"><span class="linenos">458</span></a><span class="sd">        Raises:</span>
-</span><span id="Label-459"><a href="#Label-459"><span class="linenos">459</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
-</span><span id="Label-460"><a href="#Label-460"><span class="linenos">460</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label-461"><a href="#Label-461"><span class="linenos">461</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
-</span><span id="Label-462"><a href="#Label-462"><span class="linenos">462</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
-</span><span id="Label-463"><a href="#Label-463"><span class="linenos">463</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
-</span><span id="Label-464"><a href="#Label-464"><span class="linenos">464</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
-</span><span id="Label-465"><a href="#Label-465"><span class="linenos">465</span></a>        <span class="p">)</span>
+</span><span id="Label-450"><a href="#Label-450"><span class="linenos">450</span></a><span class="sd">        Args:</span>
+</span><span id="Label-451"><a href="#Label-451"><span class="linenos">451</span></a><span class="sd">            name: The symbolic name for this label.</span>
+</span><span id="Label-452"><a href="#Label-452"><span class="linenos">452</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label-453"><a href="#Label-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="Label-454"><a href="#Label-454"><span class="linenos">454</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
+</span><span id="Label-455"><a href="#Label-455"><span class="linenos">455</span></a>
+</span><span id="Label-456"><a href="#Label-456"><span class="linenos">456</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="Label-457"><a href="#Label-457"><span class="linenos">457</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
+</span><span id="Label-458"><a href="#Label-458"><span class="linenos">458</span></a>
+</span><span id="Label-459"><a href="#Label-459"><span class="linenos">459</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
+</span><span id="Label-460"><a href="#Label-460"><span class="linenos">460</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
+</span><span id="Label-461"><a href="#Label-461"><span class="linenos">461</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
+</span><span id="Label-462"><a href="#Label-462"><span class="linenos">462</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
+</span><span id="Label-463"><a href="#Label-463"><span class="linenos">463</span></a>
+</span><span id="Label-464"><a href="#Label-464"><span class="linenos">464</span></a><span class="sd">        Args:</span>
+</span><span id="Label-465"><a href="#Label-465"><span class="linenos">465</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
 </span><span id="Label-466"><a href="#Label-466"><span class="linenos">466</span></a>
-</span><span id="Label-467"><a href="#Label-467"><span class="linenos">467</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Label-468"><a href="#Label-468"><span class="linenos">468</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
-</span><span id="Label-469"><a href="#Label-469"><span class="linenos">469</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
-</span><span id="Label-470"><a href="#Label-470"><span class="linenos">470</span></a>
-</span><span id="Label-471"><a href="#Label-471"><span class="linenos">471</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
-</span><span id="Label-472"><a href="#Label-472"><span class="linenos">472</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation (without colon).&quot;&quot;&quot;</span>
-</span><span id="Label-473"><a href="#Label-473"><span class="linenos">473</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
-</span><span id="Label-474"><a href="#Label-474"><span class="linenos">474</span></a>
-</span><span id="Label-475"><a href="#Label-475"><span class="linenos">475</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
-</span><span id="Label-476"><a href="#Label-476"><span class="linenos">476</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
-</span><span id="Label-477"><a href="#Label-477"><span class="linenos">477</span></a>
-</span><span id="Label-478"><a href="#Label-478"><span class="linenos">478</span></a><span class="sd">        Args:</span>
-</span><span id="Label-479"><a href="#Label-479"><span class="linenos">479</span></a><span class="sd">            text: The comment text to associate with the label.</span>
-</span><span id="Label-480"><a href="#Label-480"><span class="linenos">480</span></a>
-</span><span id="Label-481"><a href="#Label-481"><span class="linenos">481</span></a><span class="sd">        Returns:</span>
-</span><span id="Label-482"><a href="#Label-482"><span class="linenos">482</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
-</span><span id="Label-483"><a href="#Label-483"><span class="linenos">483</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label-484"><a href="#Label-484"><span class="linenos">484</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-</span><span id="Label-485"><a href="#Label-485"><span class="linenos">485</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
-</span><span id="Label-486"><a href="#Label-486"><span class="linenos">486</span></a>        <span class="k">return</span> <span class="n">new_label</span>
-</span><span id="Label-487"><a href="#Label-487"><span class="linenos">487</span></a>
-</span><span id="Label-488"><a href="#Label-488"><span class="linenos">488</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
-</span><span id="Label-489"><a href="#Label-489"><span class="linenos">489</span></a>        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="ow">is</span> <span class="ow">not</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
-</span><span id="Label-490"><a href="#Label-490"><span class="linenos">490</span></a>            <span class="k">return</span> <span class="kc">False</span>
-</span><span id="Label-491"><a href="#Label-491"><span class="linenos">491</span></a>        <span class="c1"># Exclude comment from equality check</span>
-</span><span id="Label-492"><a href="#Label-492"><span class="linenos">492</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
+</span><span id="Label-467"><a href="#Label-467"><span class="linenos">467</span></a><span class="sd">        Raises:</span>
+</span><span id="Label-468"><a href="#Label-468"><span class="linenos">468</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
+</span><span id="Label-469"><a href="#Label-469"><span class="linenos">469</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label-470"><a href="#Label-470"><span class="linenos">470</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
+</span><span id="Label-471"><a href="#Label-471"><span class="linenos">471</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
+</span><span id="Label-472"><a href="#Label-472"><span class="linenos">472</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
+</span><span id="Label-473"><a href="#Label-473"><span class="linenos">473</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
+</span><span id="Label-474"><a href="#Label-474"><span class="linenos">474</span></a>        <span class="p">)</span>
+</span><span id="Label-475"><a href="#Label-475"><span class="linenos">475</span></a>
+</span><span id="Label-476"><a href="#Label-476"><span class="linenos">476</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__repr__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Label-477"><a href="#Label-477"><span class="linenos">477</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return Python API representation.&quot;&quot;&quot;</span>
+</span><span id="Label-478"><a href="#Label-478"><span class="linenos">478</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="Label-479"><a href="#Label-479"><span class="linenos">479</span></a>
+</span><span id="Label-480"><a href="#Label-480"><span class="linenos">480</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__str__</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+</span><span id="Label-481"><a href="#Label-481"><span class="linenos">481</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Return assembly text representation (without colon).&quot;&quot;&quot;</span>
+</span><span id="Label-482"><a href="#Label-482"><span class="linenos">482</span></a>        <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&quot;</span>
+</span><span id="Label-483"><a href="#Label-483"><span class="linenos">483</span></a>
+</span><span id="Label-484"><a href="#Label-484"><span class="linenos">484</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
+</span><span id="Label-485"><a href="#Label-485"><span class="linenos">485</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
+</span><span id="Label-486"><a href="#Label-486"><span class="linenos">486</span></a>
+</span><span id="Label-487"><a href="#Label-487"><span class="linenos">487</span></a><span class="sd">        Args:</span>
+</span><span id="Label-488"><a href="#Label-488"><span class="linenos">488</span></a><span class="sd">            text: The comment text to associate with the label.</span>
+</span><span id="Label-489"><a href="#Label-489"><span class="linenos">489</span></a>
+</span><span id="Label-490"><a href="#Label-490"><span class="linenos">490</span></a><span class="sd">        Returns:</span>
+</span><span id="Label-491"><a href="#Label-491"><span class="linenos">491</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
+</span><span id="Label-492"><a href="#Label-492"><span class="linenos">492</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label-493"><a href="#Label-493"><span class="linenos">493</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="Label-494"><a href="#Label-494"><span class="linenos">494</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
+</span><span id="Label-495"><a href="#Label-495"><span class="linenos">495</span></a>        <span class="k">return</span> <span class="n">new_label</span>
+</span><span id="Label-496"><a href="#Label-496"><span class="linenos">496</span></a>
+</span><span id="Label-497"><a href="#Label-497"><span class="linenos">497</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">other</span><span class="p">):</span>
+</span><span id="Label-498"><a href="#Label-498"><span class="linenos">498</span></a>        <span class="k">if</span> <span class="nb">type</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="ow">is</span> <span class="ow">not</span> <span class="nb">type</span><span class="p">(</span><span class="n">other</span><span class="p">):</span>
+</span><span id="Label-499"><a href="#Label-499"><span class="linenos">499</span></a>            <span class="k">return</span> <span class="kc">False</span>
+</span><span id="Label-500"><a href="#Label-500"><span class="linenos">500</span></a>        <span class="c1"># Exclude comment from equality check</span>
+</span><span id="Label-501"><a href="#Label-501"><span class="linenos">501</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">==</span> <span class="n">other</span><span class="o">.</span><span class="n">name</span>
 </span></pre></div>
 
 
@@ -1850,14 +1868,14 @@ indices. Labels can only be used as destinations for jump and call instructions.
 
     </div>
     <a class="headerlink" href="#Label.__init__"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.__init__-438"><a href="#Label.__init__-438"><span class="linenos">438</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
-</span><span id="Label.__init__-439"><a href="#Label.__init__-439"><span class="linenos">439</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
-</span><span id="Label.__init__-440"><a href="#Label.__init__-440"><span class="linenos">440</span></a>
-</span><span id="Label.__init__-441"><a href="#Label.__init__-441"><span class="linenos">441</span></a><span class="sd">        Args:</span>
-</span><span id="Label.__init__-442"><a href="#Label.__init__-442"><span class="linenos">442</span></a><span class="sd">            name: The symbolic name for this label.</span>
-</span><span id="Label.__init__-443"><a href="#Label.__init__-443"><span class="linenos">443</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label.__init__-444"><a href="#Label.__init__-444"><span class="linenos">444</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
-</span><span id="Label.__init__-445"><a href="#Label.__init__-445"><span class="linenos">445</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.__init__-447"><a href="#Label.__init__-447"><span class="linenos">447</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
+</span><span id="Label.__init__-448"><a href="#Label.__init__-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Initialize a label with a given name.</span>
+</span><span id="Label.__init__-449"><a href="#Label.__init__-449"><span class="linenos">449</span></a>
+</span><span id="Label.__init__-450"><a href="#Label.__init__-450"><span class="linenos">450</span></a><span class="sd">        Args:</span>
+</span><span id="Label.__init__-451"><a href="#Label.__init__-451"><span class="linenos">451</span></a><span class="sd">            name: The symbolic name for this label.</span>
+</span><span id="Label.__init__-452"><a href="#Label.__init__-452"><span class="linenos">452</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label.__init__-453"><a href="#Label.__init__-453"><span class="linenos">453</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">name</span> <span class="o">=</span> <span class="n">name</span>
+</span><span id="Label.__init__-454"><a href="#Label.__init__-454"><span class="linenos">454</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">comment</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="s2">&quot;&quot;</span>
 </span></pre></div>
 
 
@@ -1905,25 +1923,25 @@ indices. Labels can only be used as destinations for jump and call instructions.
 
     </div>
     <a class="headerlink" href="#Label.resolve"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.resolve-447"><a href="#Label.resolve-447"><span class="linenos">447</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
-</span><span id="Label.resolve-448"><a href="#Label.resolve-448"><span class="linenos">448</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
-</span><span id="Label.resolve-449"><a href="#Label.resolve-449"><span class="linenos">449</span></a>
-</span><span id="Label.resolve-450"><a href="#Label.resolve-450"><span class="linenos">450</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
-</span><span id="Label.resolve-451"><a href="#Label.resolve-451"><span class="linenos">451</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
-</span><span id="Label.resolve-452"><a href="#Label.resolve-452"><span class="linenos">452</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
-</span><span id="Label.resolve-453"><a href="#Label.resolve-453"><span class="linenos">453</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
-</span><span id="Label.resolve-454"><a href="#Label.resolve-454"><span class="linenos">454</span></a>
-</span><span id="Label.resolve-455"><a href="#Label.resolve-455"><span class="linenos">455</span></a><span class="sd">        Args:</span>
-</span><span id="Label.resolve-456"><a href="#Label.resolve-456"><span class="linenos">456</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
-</span><span id="Label.resolve-457"><a href="#Label.resolve-457"><span class="linenos">457</span></a>
-</span><span id="Label.resolve-458"><a href="#Label.resolve-458"><span class="linenos">458</span></a><span class="sd">        Raises:</span>
-</span><span id="Label.resolve-459"><a href="#Label.resolve-459"><span class="linenos">459</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
-</span><span id="Label.resolve-460"><a href="#Label.resolve-460"><span class="linenos">460</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label.resolve-461"><a href="#Label.resolve-461"><span class="linenos">461</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
-</span><span id="Label.resolve-462"><a href="#Label.resolve-462"><span class="linenos">462</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
-</span><span id="Label.resolve-463"><a href="#Label.resolve-463"><span class="linenos">463</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
-</span><span id="Label.resolve-464"><a href="#Label.resolve-464"><span class="linenos">464</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
-</span><span id="Label.resolve-465"><a href="#Label.resolve-465"><span class="linenos">465</span></a>        <span class="p">)</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.resolve-456"><a href="#Label.resolve-456"><span class="linenos">456</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">resolve</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">cpu</span><span class="p">:</span> <span class="n">DT31</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">int</span><span class="p">:</span>
+</span><span id="Label.resolve-457"><a href="#Label.resolve-457"><span class="linenos">457</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Resolve the label to an instruction position.</span>
+</span><span id="Label.resolve-458"><a href="#Label.resolve-458"><span class="linenos">458</span></a>
+</span><span id="Label.resolve-459"><a href="#Label.resolve-459"><span class="linenos">459</span></a><span class="sd">        This method should never be called during normal execution. Labels must be</span>
+</span><span id="Label.resolve-460"><a href="#Label.resolve-460"><span class="linenos">460</span></a><span class="sd">        resolved during the assembly process before the program runs. If this method</span>
+</span><span id="Label.resolve-461"><a href="#Label.resolve-461"><span class="linenos">461</span></a><span class="sd">        is called, it indicates the program was not assembled or the label was used</span>
+</span><span id="Label.resolve-462"><a href="#Label.resolve-462"><span class="linenos">462</span></a><span class="sd">        incorrectly (e.g., in an arithmetic operation instead of a jump destination).</span>
+</span><span id="Label.resolve-463"><a href="#Label.resolve-463"><span class="linenos">463</span></a>
+</span><span id="Label.resolve-464"><a href="#Label.resolve-464"><span class="linenos">464</span></a><span class="sd">        Args:</span>
+</span><span id="Label.resolve-465"><a href="#Label.resolve-465"><span class="linenos">465</span></a><span class="sd">            cpu: The DT31 CPU instance (unused).</span>
+</span><span id="Label.resolve-466"><a href="#Label.resolve-466"><span class="linenos">466</span></a>
+</span><span id="Label.resolve-467"><a href="#Label.resolve-467"><span class="linenos">467</span></a><span class="sd">        Raises:</span>
+</span><span id="Label.resolve-468"><a href="#Label.resolve-468"><span class="linenos">468</span></a><span class="sd">            RuntimeError: Always raised, as labels must be resolved during assembly.</span>
+</span><span id="Label.resolve-469"><a href="#Label.resolve-469"><span class="linenos">469</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label.resolve-470"><a href="#Label.resolve-470"><span class="linenos">470</span></a>        <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span>
+</span><span id="Label.resolve-471"><a href="#Label.resolve-471"><span class="linenos">471</span></a>            <span class="sa">f</span><span class="s2">&quot;Unresolved label &#39;</span><span class="si">{</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="si">}</span><span class="s2">&#39; encountered at runtime. &quot;</span>
+</span><span id="Label.resolve-472"><a href="#Label.resolve-472"><span class="linenos">472</span></a>            <span class="s2">&quot;Programs containing labels must be assembled using assemble() before execution. &quot;</span>
+</span><span id="Label.resolve-473"><a href="#Label.resolve-473"><span class="linenos">473</span></a>            <span class="s2">&quot;Labels can only be used as jump/call destinations, not in arithmetic or other operations.&quot;</span>
+</span><span id="Label.resolve-474"><a href="#Label.resolve-474"><span class="linenos">474</span></a>        <span class="p">)</span>
 </span></pre></div>
 
 
@@ -1960,18 +1978,18 @@ incorrectly (e.g., in an arithmetic operation instead of a jump destination).</p
 
     </div>
     <a class="headerlink" href="#Label.with_comment"></a>
-            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.with_comment-475"><a href="#Label.with_comment-475"><span class="linenos">475</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
-</span><span id="Label.with_comment-476"><a href="#Label.with_comment-476"><span class="linenos">476</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
-</span><span id="Label.with_comment-477"><a href="#Label.with_comment-477"><span class="linenos">477</span></a>
-</span><span id="Label.with_comment-478"><a href="#Label.with_comment-478"><span class="linenos">478</span></a><span class="sd">        Args:</span>
-</span><span id="Label.with_comment-479"><a href="#Label.with_comment-479"><span class="linenos">479</span></a><span class="sd">            text: The comment text to associate with the label.</span>
-</span><span id="Label.with_comment-480"><a href="#Label.with_comment-480"><span class="linenos">480</span></a>
-</span><span id="Label.with_comment-481"><a href="#Label.with_comment-481"><span class="linenos">481</span></a><span class="sd">        Returns:</span>
-</span><span id="Label.with_comment-482"><a href="#Label.with_comment-482"><span class="linenos">482</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
-</span><span id="Label.with_comment-483"><a href="#Label.with_comment-483"><span class="linenos">483</span></a><span class="sd">        &quot;&quot;&quot;</span>
-</span><span id="Label.with_comment-484"><a href="#Label.with_comment-484"><span class="linenos">484</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
-</span><span id="Label.with_comment-485"><a href="#Label.with_comment-485"><span class="linenos">485</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
-</span><span id="Label.with_comment-486"><a href="#Label.with_comment-486"><span class="linenos">486</span></a>        <span class="k">return</span> <span class="n">new_label</span>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="Label.with_comment-484"><a href="#Label.with_comment-484"><span class="linenos">484</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">with_comment</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">text</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Label</span><span class="p">:</span>
+</span><span id="Label.with_comment-485"><a href="#Label.with_comment-485"><span class="linenos">485</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a new label with the specified comment.</span>
+</span><span id="Label.with_comment-486"><a href="#Label.with_comment-486"><span class="linenos">486</span></a>
+</span><span id="Label.with_comment-487"><a href="#Label.with_comment-487"><span class="linenos">487</span></a><span class="sd">        Args:</span>
+</span><span id="Label.with_comment-488"><a href="#Label.with_comment-488"><span class="linenos">488</span></a><span class="sd">            text: The comment text to associate with the label.</span>
+</span><span id="Label.with_comment-489"><a href="#Label.with_comment-489"><span class="linenos">489</span></a>
+</span><span id="Label.with_comment-490"><a href="#Label.with_comment-490"><span class="linenos">490</span></a><span class="sd">        Returns:</span>
+</span><span id="Label.with_comment-491"><a href="#Label.with_comment-491"><span class="linenos">491</span></a><span class="sd">            A new Label instance with the same name but with the comment set.</span>
+</span><span id="Label.with_comment-492"><a href="#Label.with_comment-492"><span class="linenos">492</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="Label.with_comment-493"><a href="#Label.with_comment-493"><span class="linenos">493</span></a>        <span class="n">new_label</span> <span class="o">=</span> <span class="n">Label</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">name</span><span class="p">)</span>
+</span><span id="Label.with_comment-494"><a href="#Label.with_comment-494"><span class="linenos">494</span></a>        <span class="n">new_label</span><span class="o">.</span><span class="n">comment</span> <span class="o">=</span> <span class="n">text</span>
+</span><span id="Label.with_comment-495"><a href="#Label.with_comment-495"><span class="linenos">495</span></a>        <span class="k">return</span> <span class="n">new_label</span>
 </span></pre></div>
 
 

--- a/src/dt31/operands.py
+++ b/src/dt31/operands.py
@@ -67,7 +67,16 @@ class Literal(Operand):
     def __str__(self) -> str:
         """Return assembly text representation."""
         if self.is_char:
-            return f"'{chr(self.value)}'"
+            char_str = chr(self.value)
+            # Special case for single quote: repr("'") -> "'" (uses double quotes)
+            # We need to escape it for our single-quote syntax
+            if char_str == "'":
+                return r"'\''"
+            # For all other characters, repr() handles escaping correctly
+            # repr("A") -> "'A'", repr("\n") -> "'\n'", repr("\\") -> "'\\\\'", etc.
+            escaped = repr(char_str)
+            # Strip the outer quotes that repr() adds and wrap in single quotes
+            return f"'{escaped[1:-1]}'"
         return str(self.value)
 
     def __eq__(self, other) -> bool:

--- a/tests/test_operands.py
+++ b/tests/test_operands.py
@@ -283,3 +283,30 @@ def test_with_comment_method_label():
     assert commented_label.comment == "Loop start"
     assert commented_label == label
     assert commented_label is not label
+
+
+def test_lc_escape_sequences_str():
+    """Test that character literals with escape sequences render correctly."""
+    # Newline
+    lc_newline = LC["\n"]
+    assert str(lc_newline) == "'\\n'"
+
+    # Tab
+    lc_tab = LC["\t"]
+    assert str(lc_tab) == "'\\t'"
+
+    # Carriage return
+    lc_cr = LC["\r"]
+    assert str(lc_cr) == "'\\r'"
+
+    # Backslash
+    lc_backslash = LC["\\"]
+    assert str(lc_backslash) == "'\\\\'"
+
+    # Single quote
+    lc_quote = LC["'"]
+    assert str(lc_quote) == "'\\''"
+
+    # Regular character (should not be escaped)
+    lc_regular = LC["A"]
+    assert str(lc_regular) == "'A'"


### PR DESCRIPTION
## Summary
- Fixed character literals with escape sequences being rendered as actual characters instead of escape sequences
- Updated `Literal.__str__()` to properly escape special characters using `repr()` with special handling for single quotes

## Test plan
- [x] Added comprehensive test coverage for escape sequences (`\n`, `\t`, `\r`, `\\`, `\'`)
- [x] All 442 tests pass
- [x] Round-trip parsing and formatting works correctly